### PR TITLE
Use `dojo-core/load` to load locale messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
   - BROWSERSTACK_USERNAME: dtktestaccount1
   - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
-cache:
-  directories:
-  - node_modules
 install:
 - travis_retry npm install grunt-cli
 - travis_retry npm install

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,6 +3,7 @@ import has from 'dojo-core/has';
 import global from 'dojo-core/global';
 import { Handle } from 'dojo-interfaces/core';
 import { assign } from 'dojo-core/lang';
+import load from 'dojo-core/load';
 import Map from 'dojo-shim/Map';
 import Promise from 'dojo-shim/Promise';
 
@@ -101,25 +102,9 @@ const loadLocaleBundles = (function () {
 		});
 	}
 
-	if (has('host-node')) {
-		return function<T extends Messages>(paths: string[]): Promise<T[]> {
-			const modules = paths.map((path: string): LocaleModule<T> => {
-				return global.require(path) as LocaleModule<T>;
-			});
-
-			return Promise.all(mapMessages(modules));
-		};
-	}
-
 	return function<T extends Messages>(paths: string[]): Promise<T[]> {
-		return new Promise<T[]>((resolve, reject) => {
-			const require = global.require;
-			require.on('error', (error: Error) => {
-				reject(error);
-			});
-			require(paths, (...modules: LocaleModule<T>[]) => {
-				resolve(mapMessages(modules));
-			});
+		return load(global.require, ...paths).then((modules: LocaleModule<T>[]) => {
+			return mapMessages(modules);
 		});
 	};
 })();

--- a/tslint.json
+++ b/tslint.json
@@ -22,7 +22,6 @@
 		"no-console": false,
 		"no-construct": false,
 		"no-debugger": true,
-		"no-duplicate-key": true,
 		"no-duplicate-variable": true,
 		"no-empty": false,
 		"no-eval": true,


### PR DESCRIPTION
**Type:** feature

**Description:** 

Remove direct use of the `dojo-loader` in favor of using `dojo-core/load` to load locale messages.

**Related Issue:** #22

Please review this checklist before submitting your PR:
- [x] There is a related issue
- [x] All contributors have signed a CLA
- [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [x] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged
