### PR TITLE
Migrate to @types and dojo-interfaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,29 +18,22 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-compose": ">=2.0.0-beta.13",
-    "dojo-core": ">=2.0.0-alpha.15",
-    "dojo-has": ">=2.0.0-alpha.5",
-    "dojo-shim": ">=2.0.0-beta.2"
+    "dojo-compose": ">=2.0.0-beta.15",
+    "dojo-core": ">=2.0.0-alpha.16",
+    "dojo-has": ">=2.0.0-alpha.6",
+    "dojo-shim": ">=2.0.0-beta.3"
   },
   "devDependencies": {
-    "codecov.io": "0.1.6",
+    "@types/chai": "~3.4.0",
+    "@types/es6-shim": "~0.31.0",
+    "@types/glob": "~5.0.0",
+    "@types/grunt": "~0.4.0",
+    "dojo-interfaces": ">=2.0.0-alpha.4",
     "dojo-loader": ">=2.0.0-beta.7",
-    "dts-generator": "~1.7.0",
-    "glob": "^7.0.3",
     "grunt": "^1.0.1",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-watch": "^1.0.0",
-    "grunt-dojo2": ">=2.0.0-beta.18",
-    "grunt-release": "0.13.1",
-    "grunt-text-replace": "0.4.0",
-    "grunt-ts": "^5.5.1",
-    "grunt-tslint": "^3.1.0",
-    "grunt-typings": ">=0.1.5",
-    "intern": "~3.2.3",
-    "istanbul": "0.4.3",
-    "remap-istanbul": ">=0.6.4",
+    "grunt-dojo2": ">=2.0.0-beta.19",
+    "intern": "~3.3.2",
+    "istanbul": "~0.4.5",
     "tslint": "^3.15.1",
     "typescript": "~2.0.3"
   }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:interface-name */
 import has from 'dojo-core/has';
 import global from 'dojo-core/global';
-import { Handle } from 'dojo-core/interfaces';
+import { Handle } from 'dojo-interfaces/core';
 import { assign } from 'dojo-core/lang';
 import Map from 'dojo-shim/Map';
 import Promise from 'dojo-shim/Promise';

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -1,6 +1,6 @@
 import global from 'dojo-core/global';
 import has from 'dojo-core/has';
-import { Handle } from 'dojo-core/interfaces';
+import { Handle } from 'dojo-interfaces/core';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import i18n, { getCachedMessages, invalidate, LocaleContext, LocaleState, Messages, switchLocale, systemLocale } from '../../src/i18n';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
@@ -7,7 +7,6 @@
 		"noImplicitThis": true,
 		"strictNullChecks": true,
 		"outDir": "_build/",
-		"baseUrl": "node_modules",
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",

--- a/typings.json
+++ b/typings.json
@@ -1,19 +1,11 @@
 {
 	"name": "dojo-i18n",
-	"devDependencies": {
-		"chai": "registry:npm/chai#3.5.0+20160415060238",
-		"glob": "registry:npm/glob#6.0.0+20160211003958"
-	},
 	"globalDevDependencies": {
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo-loader": "npm:dojo-loader",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
-		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
+		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"node": "github:dojo/typings/custom/node/node.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
 	}
 }


### PR DESCRIPTION
Resolves #24. Updates typings to use `@types`, updates dependency versions, and incorporates `dojo-interfaces`.