### PR TITLE
Validate locales, fix Globalize/Cldr module IDs, and update CLDR data loader.

### DIFF
--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -6,7 +6,7 @@ import load from 'dojo-core/load';
 import coreRequest, { Response } from 'dojo-core/request';
 import has from 'dojo-has/has';
 import Promise from 'dojo-shim/Promise';
-import * as Globalize from 'globalize/dist/globalize';
+import * as Globalize from 'globalize';
 import supportedMain from './locales';
 import { generateLocales } from '../util';
 

--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -79,18 +79,18 @@ const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
 			return load(require, ...paths);
 		};
 	}
-	else if (typeof define === 'function' && define.amd) {
-		return function (paths: string[]): Promise<CldrData[]> {
-			return Promise.all(paths.map((path: string): Promise<CldrData> => {
-				return <Promise<CldrData>> coreRequest.get(require.toUrl(path) + '.json', {
-					responseType: 'json'
-				}).then((response: Response<CldrData>) => response.data as CldrData);
-			}));
-		};
-	}
-	else {
-		throw new Error('Unknown loader');
-	}
+
+	return function (paths: string[]): Promise<CldrData[]> {
+		return Promise.all(paths.map((path: string): Promise<CldrData> => {
+			if (typeof require.toUrl === 'function') {
+				path = require.toUrl(path);
+			}
+
+			return <Promise<CldrData>> coreRequest.get(`${path}.json`, {
+				responseType: 'json'
+			}).then((response: Response<CldrData>) => response.data as CldrData);
+		}));
+	};
 })();
 
 /**

--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -1,14 +1,20 @@
 // required for Globalize/Cldr to properly resolve locales in the browser.
-import 'cldr/unresolved';
+import 'cldrjs/dist/cldr/unresolved';
+import { Require } from 'dojo-interfaces/loader';
 import Map from 'dojo-shim/Map';
-import global from 'dojo-core/global';
 import load from 'dojo-core/load';
 import coreRequest, { Response } from 'dojo-core/request';
 import has from 'dojo-has/has';
 import Promise from 'dojo-shim/Promise';
-import * as Globalize from 'globalize/globalize';
+import * as Globalize from 'globalize/dist/globalize';
 import supportedMain from './locales';
 import { generateLocales } from '../util';
+
+declare const require: Require;
+declare const define: {
+	(...args: any[]): any;
+	amd: any;
+};
 
 /**
  * Describes the form of an individual CLDR data object.
@@ -70,13 +76,13 @@ const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
 	if (has('host-node')) {
 		return function (paths: string[]): Promise<{}[]> {
 			paths = paths.map(path => path + '.json');
-			return load(global.require, ...paths);
+			return load(require, ...paths);
 		};
 	}
-	else if (typeof global.define === 'function' && global.define.amd) {
+	else if (typeof define === 'function' && define.amd) {
 		return function (paths: string[]): Promise<CldrData[]> {
 			return Promise.all(paths.map((path: string): Promise<CldrData> => {
-				return <Promise<CldrData>> coreRequest.get(global.require.toUrl(path) + '.json', {
+				return <Promise<CldrData>> coreRequest.get(require.toUrl(path) + '.json', {
 					responseType: 'json'
 				}).then((response: Response<CldrData>) => response.data as CldrData);
 			}));

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,11 +4,11 @@ import has from 'dojo-core/has';
 import global from 'dojo-core/global';
 import { assign } from 'dojo-core/lang';
 import load from 'dojo-core/load';
-import { Handle } from 'dojo-core/interfaces';
+import { Handle } from 'dojo-interfaces/core';
 import Map from 'dojo-shim/Map';
 import Observable, { Observer, Subscription, SubscriptionObserver } from 'dojo-shim/Observable';
 import Promise from 'dojo-shim/Promise';
-import * as Globalize from 'globalize/globalize/message';
+import * as Globalize from 'globalize/dist/globalize/message';
 import loadCldrData from './cldr/load';
 import { generateLocales, normalizeLocale } from './util';
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -280,7 +280,7 @@ export function getMessageFormatter(bundlePath: string, key: string, locale?: st
 function i18n<T extends Messages>(bundle: Bundle<T>, locale?: string): Promise<T> {
 	const { bundlePath, locales, messages } = bundle;
 	const path = bundlePath.replace(/\/$/, '');
-	const currentLocale = locale || getRootLocale();
+	const currentLocale = locale ? normalizeLocale(locale) : getRootLocale();
 
 	try {
 		validatePath(path);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -390,7 +390,7 @@ export function ready(): Promise<void> {
  */
 export function switchLocale(locale: string): Promise<void> {
 	const previous = rootLocale;
-	rootLocale = normalizeLocale(locale);
+	rootLocale = locale ? normalizeLocale(locale) : '';
 
 	return ready().then(() => {
 		if (previous !== rootLocale) {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -62,7 +62,7 @@ export interface Messages {
 	[key: string]: string;
 }
 
-const PATH_SEPARATOR: string = has('host-node') ? global.require('path').sep : '/';
+const PATH_SEPARATOR: string = has('host-node') ? require('path').sep : '/';
 const VALID_PATH_PATTERN = new RegExp(PATH_SEPARATOR + '[^' + PATH_SEPARATOR + ']+$');
 const bundleMap = new Map<string, Map<string, Messages>>();
 const formatterMap = new Map<string, MessageFormatter>();
@@ -81,7 +81,7 @@ const loadLocaleBundles = (function () {
 	}
 
 	return function<T extends Messages>(paths: string[]): Promise<T[]> {
-		return load(global.require, ...paths).then((modules: LocaleModule<T>[]) => {
+		return load(<any> require, ...paths).then((modules: LocaleModule<T>[]) => {
 			return mapMessages(modules);
 		});
 	};
@@ -416,7 +416,7 @@ export const systemLocale: string = (function () {
 		systemLocale = navigator.language || navigator.userLanguage;
 	}
 	else if (has('host-node')) {
-		systemLocale = global.process.env.LANG;
+		systemLocale = process.env.LANG;
 	}
 	return normalizeLocale(systemLocale);
 })();

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,6 @@
+// Matches an ISO 639.1/639.2 compatible language, followed by optional subtags.
+const VALID_LOCALE_PATTERN = /^[a-z]{2,3}(-[a-z0-9\-\_]+)?$/i;
+
 /**
  * Retrieve a list of locales that can provide substitute for the specified locale
  * (including itself).
@@ -37,7 +40,7 @@ export const normalizeLocale = (function () {
 		return value.replace(/(\-|_)$/, '');
 	}
 
-	return function (locale: string): string {
+	function normalize(locale: string): string {
 		if (locale.indexOf('.') === -1) {
 			return removeTrailingSeparator(locale);
 		}
@@ -45,5 +48,32 @@ export const normalizeLocale = (function () {
 		return locale.split('.').slice(0, -1).map((part: string): string => {
 			return removeTrailingSeparator(part).replace(/_/g, '-');
 		}).join('-');
+	}
+
+	return function (locale: string): string {
+		const normalized = normalize(locale);
+
+		if (!validateLocale(normalized)) {
+			throw new Error(`${normalized} is not a valid locale.`);
+		}
+
+		return normalized;
 	};
 })();
+
+/**
+ * Validates that the provided locale at least begins with a ISO 639.1/639.2 comptabile language subtag,
+ * and that any additional subtags contain only valid characters.
+ *
+ * While locales should adhere to the guidelines set forth by RFC 5646 (https://tools.ietf.org/html/rfc5646),
+ * only the language subtag is strictly enforced.
+ *
+ * @param locale
+ * The locale to validate.
+ *
+ * @return
+ * `true` if the locale is valid; `false` otherwise.
+ */
+export function validateLocale(locale: string): boolean {
+	return VALID_LOCALE_PATTERN.test(locale);
+}

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -61,7 +61,7 @@ export const loaderOptions = {
 		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
 		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
 		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
-		{ name: 'globalize', location: 'node_modules/globalize' },
+		{ name: 'globalize', location: 'node_modules/globalize', main: 'dist/globalize' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	],
 	map: {

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -56,18 +56,21 @@ export const loaderOptions = {
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'cldr-data', location: 'node_modules/cldr-data' },
-		{ name: 'cldr', location: 'node_modules/cldrjs/dist', main: 'cldr' },
+		{ name: 'cldrjs', location: 'node_modules/cldrjs' },
 		{ name: 'dojo-compose', location: 'node_modules/dojo-compose' },
 		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
 		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
 		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
-		{ name: 'globalize', location: 'node_modules/globalize/dist' },
+		{ name: 'globalize', location: 'node_modules/globalize' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	],
-	paths: {
-		'cldr/event': 'node_modules/cldrjs/dist/cldr/event',
-		'cldr/supplemental': 'node_modules/cldrjs/dist/cldr/supplemental',
-		'cldr/unresolved': 'node_modules/cldrjs/dist/cldr/unresolved'
+	map: {
+		globalize: {
+			'cldr': 'cldrjs/dist/cldr',
+			'cldr/event': 'cldrjs/dist/cldr/event',
+			'cldr/supplemental': 'cldrjs/dist/cldr/supplemental',
+			'cldr/unresolved': 'cldrjs/dist/cldr/unresolved'
+		}
 	}
 };
 

--- a/tests/unit/cldr/load.ts
+++ b/tests/unit/cldr/load.ts
@@ -47,16 +47,16 @@ registerSuite({
 		},
 
 		'assert unsupported locale'() {
-			return loadCldrData('bogus').then(() => {
+			return loadCldrData('un-SU-pported').then(() => {
 				throw Error('Test should not pass with unsupported locale.');
 			}, (error) => {
-				assert.strictEqual(error.message, 'No CLDR data for locale: bogus.');
+				assert.strictEqual(error.message, 'No CLDR data for locale: un-SU-pported.');
 			});
 		},
 
 		'assert fallback used when locale not supported'() {
-			return loadCldrData('bogus', 'en').then((result: CldrDataResponse) => {
-				const first = (<any> result['bogus'][0]).main;
+			return loadCldrData('un-SU-pported', 'en').then((result: CldrDataResponse) => {
+				const first = (<any> result['un-SU-pported'][0]).main;
 				assert(first['en'], 'Data for fallback are returned.');
 			}, (error) => {
 				throw new Error('Test should not fail when a supported fallback locale is provided.');

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -40,7 +40,7 @@ registerSuite({
 			expected = navigator.language || navigator.userLanguage;
 		}
 		else if (has('host-node')) {
-			expected = global.process.env.LANG;
+			expected = process.env.LANG;
 		}
 
 		assert.strictEqual(systemLocale, expected.replace(/^([^.]+).*/, '$1').replace(/_/g, '-'));

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -110,7 +110,7 @@ registerSuite({
 		},
 
 		'assert unsupported locale'(this: any) {
-			const cached = getCachedMessages(bundle, 'bogus-locale');
+			const cached = getCachedMessages(bundle, 'un-SU-pported');
 			assert.deepEqual(cached, bundle.messages, 'Default messages returned for unsupported locale.');
 		},
 

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { generateLocales, normalizeLocale } from '../../src/util';
+import { generateLocales, normalizeLocale, validateLocale } from '../../src/util';
 
 registerSuite({
 	name: 'util',
@@ -34,5 +34,33 @@ registerSuite({
 		assert.strictEqual(normalizeLocale('en-.UTF8'), 'en', 'Trailing hyphens are removed.');
 		assert.strictEqual(normalizeLocale('en_'), 'en', 'Trailing underscores are removed.');
 		assert.strictEqual(normalizeLocale('en_.UTF8'), 'en', 'Trailing underscores are removed.');
+
+		const validLocales = [ 'de', 'de-', 'deu', 'deu-', 'de-DE', 'de-DE-', 'deu-DE', 'deu-DE-', 'de-DE-bavarian',
+			'de-DE-bavarian-', 'deu-DE-bavarian', 'deu-DE-bavarian-', 'en-001', 'en-x-custom_value' ];
+		const invalidLocales = [ 'd', 'deut', 'de2', '@!4' ];
+
+		validLocales.forEach((locale: string) => {
+			assert.doesNotThrow(() => {
+				normalizeLocale(locale);
+			});
+		});
+		invalidLocales.forEach((locale: string) => {
+			assert.throws(() => {
+				normalizeLocale(locale);
+			}, Error, `${locale} is not a valid locale.`);
+		});
+	},
+
+	validateLocale() {
+		const validLocales = [ 'de', 'deu', 'de-DE', 'deu-DE', 'de-DE-bavarian', 'deu-DE-bavarian',
+			'en-001', 'en-x-custom_value' ];
+		const invalidLocales = [ 'd', 'deut', 'de2', '@!4' ];
+
+		validLocales.forEach((locale: string) => {
+			assert.isTrue(validateLocale(locale));
+		});
+		invalidLocales.forEach((locale: string) => {
+			assert.isFalse(validateLocale(locale));
+		});
 	}
 });

--- a/typings.json
+++ b/typings.json
@@ -9,7 +9,7 @@
 	},
 	"globalDependencies": {
 		"cldr": "github:DefinitelyTyped/DefinitelyTyped/cldr.js/cldr.js.d.ts#7de6c3dd94feaeb21f20054b9f30d5dabc5efabd",
-		"globalize": "github:mwistrand/DefinitelyTyped/globalize/globalize.d.ts#927a601f1613101325505e5936784e44cedb029c",
+		"globalize": "github:mwistrand/DefinitelyTyped/globalize/globalize.d.ts#2f4482fb5bb000feff4549d344d1558e3e673b1b",
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#003aa24b3448804a2c59e9a1d9740ca56e067e79"
 	}
 }


### PR DESCRIPTION
**Type:** bug

**Description:** 

Updates the module IDs for Globalize.js and Cldr.js so that they can be correctly used in both Node and browser environments without additional modification, validates locales provided to the `i18n` function to prevent hard-to-diagnose bugs, and simplifies the CLDR JSON loader.

**Related Issue:** #40 and #39 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged
