### PR TITLE
Remove `cldr-data` and `globalize` from peer deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,10 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "cldr-data": "~30.0.0",
     "dojo-compose": ">=2.0.0-beta.18",
     "dojo-core": ">=2.0.0-alpha.18",
     "dojo-has": ">=2.0.0-alpha.6",
-    "dojo-shim": ">=2.0.0-beta.7",
-    "globalize": "^1.1.1"
+    "dojo-shim": ">=2.0.0-beta.7"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",
@@ -41,5 +39,9 @@
     "sinon": "^1.17.6",
     "tslint": "^3.15.1",
     "typescript": "~2.1.4"
+  },
+  "dependencies": {
+    "cldr-data": "~30.0.2",
+    "globalize": "~1.2.2"
   }
 }


### PR DESCRIPTION
**Type:** bug

**Description:** 

Install `cldr-data` and `globalize` as dependencies instead of as peer
dependencies.

**Related Issue:** #42 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged
