### PR TITLE
Migrate to @dojo scoped package(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,16 +228,16 @@ i18n(bundle, 'en').then(() => {
 
 ### Date and number formatting.
 
-As with the message formatting capabilities, `dojo-i18n` relies on Globalize.js to provide locale-specific formatting for dates, times, currencies, numbers, and units. The formatters themselves are essentially light wrappers around their Globalize.js counterparts, which helps maintain consistency with the Dojo 2 ecosystem and prevents the need to work with the `Globalize` object directly. Unlike the message formatters, the date, number, and unit formatters are not cached, as they have a more complex set of options. As such, executing the various "get formatter" methods multiple times with the same inputs does not return the exact same function object.
+As with the message formatting capabilities, `@dojo/i18n` relies on Globalize.js to provide locale-specific formatting for dates, times, currencies, numbers, and units. The formatters themselves are essentially light wrappers around their Globalize.js counterparts, which helps maintain consistency with the Dojo 2 ecosystem and prevents the need to work with the `Globalize` object directly. Unlike the message formatters, the date, number, and unit formatters are not cached, as they have a more complex set of options. As such, executing the various "get formatter" methods multiple times with the same inputs does not return the exact same function object.
 
-`dojo-i18n` groups the various formatters accordingly: date and time formatters (`dojo-i18n/date`); number, currency, and pluralization formatters (`dojo-i18n/number`); and unit formatters (`dojo-i18n/unit`). Each method corresponds to a Globalize.js method (see below), and each method follows the same basic format: the last argument is an optional locale, and the penultimate argument is the method options. If specifying a locale but no options, pass `null` as the `options` argument. If no locale is provided, then the current (`i18n.locale`) is assumed.
+`@dojo/i18n` groups the various formatters accordingly: date and time formatters (`@dojo/i18n/date`); number, currency, and pluralization formatters (`@dojo/i18n/number`); and unit formatters (`@dojo/i18n/unit`). Each method corresponds to a Globalize.js method (see below), and each method follows the same basic format: the last argument is an optional locale, and the penultimate argument is the method options. If specifying a locale but no options, pass `null` as the `options` argument. If no locale is provided, then the current (`i18n.locale`) is assumed.
 
 **Note**: for convenience, these methods are synchronous, but require that all CLDR data have been loaded (see above under "Loading CLDR data").
 
 ```typescript
-import { formatDate, getDateFormatter, formatRelativeTime } from 'dojo-i18n/date';
-import { formatCurrency, getCurrencyFormatter } from 'dojo-i18n/number';
-import { formatUnit, getUnitFormatter } from 'dojo-i18n/unit';
+import { formatDate, getDateFormatter, formatRelativeTime } from '@dojo/i18n/date';
+import { formatCurrency, getCurrencyFormatter } from '@dojo/i18n/number';
+import { formatUnit, getUnitFormatter } from '@dojo/i18n/unit';
 
 const date = new Date(1815, 11, 10, 11, 27);
 
@@ -272,7 +272,7 @@ frUnitFormatter(1000); // 1 000 mètres'
 formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 ```
 
-**`dojo-i18n/date` methods:**
+**`@dojo/i18n/date` methods:**
 
 - `formatDate` => [`Globalize.formatDate`](https://github.com/globalizejs/globalize/blob/master/doc/api/date/date-formatter.md)
 - `formatRelativeTime` => [`Globalize.formatRelativeTime`](https://github.com/globalizejs/globalize/blob/master/doc/api/relative-time/relative-time-formatter.md)
@@ -281,7 +281,7 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 - `getRelativeTimeFormatter` => [`Globalize.relativeTimeFormatter`](https://github.com/globalizejs/globalize/blob/master/doc/api/relative-time/relative-time-formatter.md)
 - `parseDate` => [`Globalize.parseDate`](https://github.com/globalizejs/globalize/blob/master/doc/api/date/date-parser.md)
 
-**`dojo-i18n/number` methods:**
+**`@dojo/i18n/number` methods:**
 
 - `formatCurrency` => [`Globalize.formatCurrency`](https://github.com/globalizejs/globalize/blob/master/doc/api/currency/currency-formatter.md)
 - `formatNumber` => [`Globalize.formatNumber`](https://github.com/globalizejs/globalize/blob/master/doc/api/number/number-formatter.md)
@@ -292,7 +292,7 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 - `parseNumber` => [`Globalize.parseNumber`](https://github.com/globalizejs/globalize/blob/master/doc/api/number/number-parser.md)
 - `pluralize` => [`Globalize.plural`](https://github.com/globalizejs/globalize/blob/master/doc/api/plural/plural-generator.md)
 
-**`dojo-i18n/number` methods:**
+**`@dojo/i18n/number` methods:**
 
 - `formatUnit` => [`Globalize.formatUnit`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)
 - `getUnitFormatter` => [`Globalize.unitFormatter`](https://github.com/globalizejs/globalize/blob/master/doc/api/unit/unit-formatter.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# dojo-i18n
+# @dojo/i18n
 
-An internationalization library that provides locale-specific message loading, and support for locale-specific message, date, and number formatting. To support locale-specific formatters, `dojo-i18n` utilizes the most up-to-date [CLDR data](http://cldr.unicode.org) from [The Unicode Consortium](http://unicode.org).
+An internationalization library that provides locale-specific message loading, and support for locale-specific message, date, and number formatting. To support locale-specific formatters, `@dojo/i18n` utilizes the most up-to-date [CLDR data](http://cldr.unicode.org) from [The Unicode Consortium](http://unicode.org).
 
 **WARNING** This is _alpha_ software. It is not yet production ready, so you should use at your own risk.
 
@@ -10,7 +10,7 @@ The examples below are provided in TypeScript syntax. The package does work unde
 
 ### Message Bundle Loading
 
-`dojo-i18n` provides a means for loading locale-specific messages, and updating those messages when the locale changes. Each bundle has a default module that is `import`ed like any other TypeScript module. Locale-specific messages are then loaded via the `i18n` method. Every default bundle MUST provide a `bundlePath` that will be used to determine locale bundle locations, a `locales` array of supported locales, and a `messages` map of default messages. For example, suppose the module located at `nls/common.ts` contains the following contents:
+`@dojo/i18n` provides a means for loading locale-specific messages, and updating those messages when the locale changes. Each bundle has a default module that is `import`ed like any other TypeScript module. Locale-specific messages are then loaded via the `i18n` method. Every default bundle MUST provide a `bundlePath` that will be used to determine locale bundle locations, a `locales` array of supported locales, and a `messages` map of default messages. For example, suppose the module located at `nls/common.ts` contains the following contents:
 
 ```typescript
 const bundlePath = 'nls/common';
@@ -42,7 +42,7 @@ export default messages;
 Using the previous example as the default bundle, any locale-specific messages are loaded as follows:
 
 ```typescript
-import i18n, { Messages } from 'dojo-i18n/main';
+import i18n, { Messages } from '@dojo/i18n/main';
 import bundle from 'nls/common';
 
 i18n(bundle, 'fr').then(function (messages: Messages) {
@@ -77,7 +77,7 @@ console.log(madeUpLocaleMessages.goodbye); // "Goodbye"
 If need be, bundle caches can be cleared with `invalidate`. If called with a bundle path, only the messages for that particular bundle are removed from the cache. Otherwise, all messages are cleared:
 
 ```
-import i18n from 'dojo-i18n/main';
+import i18n from '@dojo/i18n/main';
 import bundle from 'nls/common';
 
 i18n(bundle, 'ar').then(() => {
@@ -95,7 +95,7 @@ The current locale can be accessed via the read-only property `i18n.locale`, whi
 The `switchLocale` method changes the root locale, and returns a promise that resolves when all CLDR data have loaded for the specified locale. All [`Observers`](https://github.com/dojo/shim) registered with `observeLocale` will be notified of locale changes, or notified of errors if the associated CLDR data could not be loaded (no `complete` method is currently used when switching locales).
 
 ```typescript
-import i18n, { observeLocale, switchLocale } from 'dojo-i18n/i18n';
+import i18n, { observeLocale, switchLocale } from '@dojo/i18n/i18n';
 import bundle from 'nls/bundle';
 
 // Register an `Observable`
@@ -123,10 +123,10 @@ switchLocale('de').then(() => {
 
 ### Loading CLDR data
 
-Since `dojo-i18n` automatically loads all CLDR data for the root locale, the CLDR JSON files need to be loaded manually only for additional locales used in isolated components (e.g., widgets). To load additional files manually, use the `loadCldrData` method exported by `dojo-i18n/cldr/load`:
+Since `@dojo/i18n` automatically loads all CLDR data for the root locale, the CLDR JSON files need to be loaded manually only for additional locales used in isolated components (e.g., widgets). To load additional files manually, use the `loadCldrData` method exported by `@dojo/i18n/cldr/load`:
 
 ```
-import loadCldrData, { CldrDataResponse } from 'dojo-i18n/cldr/load';
+import loadCldrData, { CldrDataResponse } from '@dojo/i18n/cldr/load';
 
 // Load data for a single locale:
 loadCldrData('ar-IQ').then((data: CldrDataResponse) => {
@@ -154,7 +154,7 @@ loadCldrData('made-UP').catch((error: Error) => {
 `switchLocale` handles loading data for new locales, but when first starting the i18n ecosystem, either `switchLocale(defaultLocale)` or the `ready` method can be used:
 
 ```typescript
-import { ready } from 'dojo-i18n/i18n';
+import { ready } from '@dojo/i18n/i18n';
 
 ready().then(() => {
 	// All CLDR data have been loaded for the root locale.
@@ -163,7 +163,7 @@ ready().then(() => {
 
 ### Custom message formatting (e.g., pluralization)
 
-`dojo-i18n` relies on [Globalize.js](https://github.com/jquery/globalize/blob/master/doc/api/message/message-formatter.md) for [ICU message formatting](http://userguide.icu-project.org/formatparse/messages), and as such all of the features offered by Globalize.js are available through `dojo-i18n`. The `i18n` module exposes two methods that handle message formatting: 1) `formatMessage`, which directly returns a formatted message based on its inputs, and 2) `getMessageFormatter`, which returns a method dedicated to formatting a single message.
+`@dojo/i18n` relies on [Globalize.js](https://github.com/jquery/globalize/blob/master/doc/api/message/message-formatter.md) for [ICU message formatting](http://userguide.icu-project.org/formatparse/messages), and as such all of the features offered by Globalize.js are available through `@dojo/i18n`. The `i18n` module exposes two methods that handle message formatting: 1) `formatMessage`, which directly returns a formatted message based on its inputs, and 2) `getMessageFormatter`, which returns a method dedicated to formatting a single message.
 
 As an example, suppose there is a locale bundle with a `guestInfo` message:
 
@@ -194,10 +194,10 @@ export default messages;
 
 The above message can be converted directly with `formatMessage`, or `getMessageFormatter` can be used to generate a function that can be used over and over with different options. Note that the formatters created and used by both methods are cached, so there is no performance penalty from compiling the same message multiple times.
 
-Since the Globalize.js formatting methods use message paths rather than the message strings themselves, the `dojo-i18n` methods also require both the bundle path and the message key, which will be resolved to a message path. If an optional locale is provided, then the corresponding locale-specific message will be used. Otherwise, the current locale is assumed.
+Since the Globalize.js formatting methods use message paths rather than the message strings themselves, the `@dojo/i18n` methods also require both the bundle path and the message key, which will be resolved to a message path. If an optional locale is provided, then the corresponding locale-specific message will be used. Otherwise, the current locale is assumed.
 
 ```typescript
-import i18n, { formatMessage, getMessageFormatter } from 'dojo-i18n/i18n';
+import i18n, { formatMessage, getMessageFormatter } from '@dojo/i18n/i18n';
 import bundle from 'nls/main';
 
 // 1. Load the messages for the locale.
@@ -302,15 +302,15 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 The easiest way to use this package is to install it via npm:
 
 ```
-$ npm install dojo-i18n
+$ npm install @dojo/i18n
 ```
 
 In addition, you can clone this repository and use the Grunt build scripts to manage the package.
 
-Using under TypeScript or ES6 modules, you would generally want to just import the dojo-i18n/i18n module:
+Using under TypeScript or ES6 modules, you would generally want to just import the @dojo/i18n/i18n module:
 
 ```typescript
-import i18n, { Messages } from 'dojo-i18n/i18n';
+import i18n, { Messages } from '@dojo/i18n/i18n';
 import messageBundle from 'path/to/bundle';
 
 i18n(messageBundle, 'fr').then((messages: Messages) => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo-i18n",
+  "name": "@dojo/i18n",
   "version": "2.0.0-pre",
   "description": "Dojo 2 Internationalization",
   "homepage": "http://dojotoolkit.org",
@@ -18,10 +18,10 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-compose": ">=2.0.0-beta.18",
-    "dojo-core": ">=2.0.0-alpha.18",
-    "dojo-has": ">=2.0.0-alpha.6",
-    "dojo-shim": ">=2.0.0-beta.7"
+    "@dojo/compose": "2.0.0-beta.21",
+    "@dojo/core": "2.0.0-alpha.19",
+    "@dojo/has": "2.0.0-alpha.7",
+    "@dojo/shim": "2.0.0-beta.8"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",
@@ -29,8 +29,8 @@
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@types/sinon": "^1.16.31",
-    "dojo-interfaces": ">=2.0.0-alpha.4",
-    "dojo-loader": ">=2.0.0-beta.7",
+    "@dojo/interfaces": "2.0.0-alpha.11",
+    "@dojo/loader": "2.0.0-beta.8",
     "grunt": "^1.0.1",
     "grunt-tslint": "^3.0.0",
     "grunt-dojo2": ">=2.0.0-beta.23",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@dojo/compose": "2.0.0-beta.21",
-    "@dojo/core": "2.0.0-alpha.19",
+    "@dojo/core": "2.0.0-alpha.20",
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/shim": "2.0.0-beta.8"
   },
@@ -30,7 +30,7 @@
     "@types/grunt": "~0.4.0",
     "@types/sinon": "^1.16.31",
     "@dojo/interfaces": "2.0.0-alpha.11",
-    "@dojo/loader": "2.0.0-beta.8",
+    "@dojo/loader": "2.0.0-beta.9",
     "grunt": "^1.0.1",
     "grunt-tslint": "^3.0.0",
     "grunt-dojo2": ">=2.0.0-beta.23",

--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -1,11 +1,11 @@
 // required for Globalize/Cldr to properly resolve locales in the browser.
 import 'cldrjs/dist/cldr/unresolved';
-import { Require } from 'dojo-interfaces/loader';
-import Map from 'dojo-shim/Map';
-import load from 'dojo-core/load';
-import coreRequest, { Response } from 'dojo-core/request';
-import has from 'dojo-has/has';
-import Promise from 'dojo-shim/Promise';
+import { Require } from '@dojo/interfaces/loader';
+import Map from '@dojo/shim/Map';
+import load from '@dojo/core/load';
+import coreRequest, { Response } from '@dojo/core/request';
+import has from '@dojo/has/has';
+import Promise from '@dojo/shim/Promise';
 import * as Globalize from 'globalize';
 import supportedMain from './locales';
 import { generateLocales } from '../util/main';

--- a/src/cldr/load/webpack.ts
+++ b/src/cldr/load/webpack.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import * as Globalize from 'globalize/dist/globalize';
 import {
 	CldrData,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,13 +1,13 @@
 /* tslint:disable:interface-name */
-import createEvented from 'dojo-compose/bases/createEvented';
-import has from 'dojo-core/has';
-import global from 'dojo-core/global';
-import { assign } from 'dojo-core/lang';
-import load from 'dojo-core/load';
-import { Handle } from 'dojo-interfaces/core';
-import Map from 'dojo-shim/Map';
-import Observable, { Observer, Subscription, SubscriptionObserver } from 'dojo-shim/Observable';
-import Promise from 'dojo-shim/Promise';
+import createEvented from '@dojo/compose/bases/createEvented';
+import has from '@dojo/core/has';
+import global from '@dojo/core/global';
+import { assign } from '@dojo/core/lang';
+import load from '@dojo/core/load';
+import { Handle } from '@dojo/interfaces/core';
+import Map from '@dojo/shim/Map';
+import Observable, { Observer, Subscription, SubscriptionObserver } from '@dojo/shim/Observable';
+import Promise from '@dojo/shim/Promise';
 import * as Globalize from 'globalize/dist/globalize/message';
 import loadCldrData from './cldr/load';
 import { generateLocales, normalizeLocale } from './util/main';

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-compose',
+	name: '@dojo/compose',
 	fixSessionCapabilities: false
 };
 
@@ -44,8 +44,8 @@ export const initialBaseUrl: string | null = (function () {
 // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
 // loader
 export const loaders = {
-	'host-browser': 'node_modules/dojo-loader/loader.min.js',
-	'host-node': 'dojo-loader'
+	'host-browser': 'node_modules/@dojo/loader/loader.min.js',
+	'host-node': '@dojo/loader'
 };
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
@@ -57,10 +57,10 @@ export const loaderOptions = {
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'cldr-data', location: 'node_modules/cldr-data' },
 		{ name: 'cldrjs', location: 'node_modules/cldrjs' },
-		{ name: 'dojo-compose', location: 'node_modules/dojo-compose' },
-		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
-		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
-		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
+		{ name: '@dojo/compose', location: 'node_modules/@dojo/compose' },
+		{ name: '@dojo/core', location: 'node_modules/@dojo/core' },
+		{ name: '@dojo/has', location: 'node_modules/@dojo/has' },
+		{ name: '@dojo/shim', location: 'node_modules/@dojo/shim' },
 		{ name: 'globalize', location: 'node_modules/globalize', main: 'dist/globalize' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	],

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -57,10 +57,7 @@ export const loaderOptions = {
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'cldr-data', location: 'node_modules/cldr-data' },
 		{ name: 'cldrjs', location: 'node_modules/cldrjs' },
-		{ name: '@dojo/compose', location: 'node_modules/@dojo/compose' },
-		{ name: '@dojo/core', location: 'node_modules/@dojo/core' },
-		{ name: '@dojo/has', location: 'node_modules/@dojo/has' },
-		{ name: '@dojo/shim', location: 'node_modules/@dojo/shim' },
+		{ name: '@dojo', location: 'node_modules/@dojo' },
 		{ name: 'globalize', location: 'node_modules/globalize', main: 'dist/globalize' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	],

--- a/tests/support/mocks/common/main.ts
+++ b/tests/support/mocks/common/main.ts
@@ -1,4 +1,4 @@
-import has from 'dojo-core/has';
+import has from '@dojo/core/has';
 
 const locales = [
 	'ar',
@@ -6,8 +6,8 @@ const locales = [
 ];
 
 // TODO: The default loader attempts to use the native Node.js `require` when running on Node. However, the Intern
-// suite uses the dojo-loader, in which case the context for requires is the location of the loader module; or in
-// this case, `node_modules/dojo-loader/loader.min.js'. Is there a better, less hacky way to handle this?
+// suite uses the @dojo/loader, in which case the context for requires is the location of the loader module; or in
+// this case, `node_modules/@dojo/loader/loader.min.js'. Is there a better, less hacky way to handle this?
 const basePath = has('host-node') ? '../_build/' : '';
 const bundlePath = basePath + 'tests/support/mocks/common/main';
 

--- a/tests/support/mocks/common/party.ts
+++ b/tests/support/mocks/common/party.ts
@@ -1,8 +1,8 @@
-import has from 'dojo-core/has';
+import has from '@dojo/core/has';
 
 // TODO: The default loader attempts to use the native Node.js `require` when running on Node. However, the Intern
-// suite uses the dojo-loader, in which case the context for requires is the location of the loader module; or in
-// this case, `node_modules/dojo-loader/loader.min.js'. Is there a better, less hacky way to handle this?
+// suite uses the @dojo/loader, in which case the context for requires is the location of the loader module; or in
+// this case, `node_modules/@dojo/loader/loader.min.js'. Is there a better, less hacky way to handle this?
 const basePath = has('host-node') ? '../_build/' : '';
 const bundlePath = basePath + 'tests/support/mocks/common/party';
 

--- a/tests/unit/cldr/load.ts
+++ b/tests/unit/cldr/load.ts
@@ -1,4 +1,4 @@
-import request from 'dojo-core/request';
+import request from '@dojo/core/request';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import * as sinon from 'sinon';

--- a/tests/unit/cldr/load/webpack.ts
+++ b/tests/unit/cldr/load/webpack.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import global from 'dojo-core/global';
+import global from '@dojo/core/global';
 import * as sinon from 'sinon';
 import { CldrDataResponse } from '../../../../src/cldr/load';
 import * as cldrLoad from '../../../../src/cldr/load';

--- a/tests/unit/date.ts
+++ b/tests/unit/date.ts
@@ -1,5 +1,5 @@
-import { around } from 'dojo-core/aspect';
-import { padStart } from 'dojo-shim/string';
+import { around } from '@dojo/core/aspect';
+import { padStart } from '@dojo/shim/string';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import loadCldrData from '../../src/cldr/load';

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -1,6 +1,6 @@
-import global from 'dojo-core/global';
-import has from 'dojo-core/has';
-import Promise from 'dojo-shim/Promise';
+import global from '@dojo/core/global';
+import has from '@dojo/core/has';
+import Promise from '@dojo/shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import * as sinon from 'sinon';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Update `package.json` and all dependency references to use `@dojo` namespace.

Related to https://github.com/dojo/meta/issues/129