### PR TITLE
Fixes #52: path issues in node on windows

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -63,7 +63,7 @@ export interface Messages {
 }
 
 const PATH_SEPARATOR: string = has('host-node') ? require('path').sep : '/';
-const VALID_PATH_PATTERN = new RegExp(PATH_SEPARATOR + '[^' + PATH_SEPARATOR + ']+$');
+const VALID_PATH_PATTERN = new RegExp(`\\${PATH_SEPARATOR}[^\\${PATH_SEPARATOR}]+\$`);
 const bundleMap = new Map<string, Map<string, Messages>>();
 const formatterMap = new Map<string, MessageFormatter>();
 const localeProducer = createEvented();
@@ -206,7 +206,7 @@ export function getCachedMessages<T extends Messages>(bundle: Bundle<T>, locale:
 		bundleMap.set(bundlePath, new Map<string, Messages>());
 		Globalize.loadMessages({
 			root: {
-				[bundlePath.replace(/\//g, '-')]: bundle.messages
+				[bundlePath.replace(new RegExp(`\\${PATH_SEPARATOR}`, 'g'), '-')]: bundle.messages
 			}
 		});
 	}
@@ -246,7 +246,7 @@ export function getCachedMessages<T extends Messages>(bundle: Bundle<T>, locale:
  * The message formatter.
  */
 export function getMessageFormatter(bundlePath: string, key: string, locale?: string): MessageFormatter {
-	const normalized = bundlePath.replace(/\//g, '-').replace(/-$/, '');
+	const normalized = bundlePath.replace(new RegExp(`\\${PATH_SEPARATOR}`, 'g'), '-').replace(/-$/, '');
 	locale = normalizeLocale(locale || getRootLocale());
 	const formatterKey = `${locale}:${bundlePath}:${key}`;
 	let formatter = formatterMap.get(formatterKey);
@@ -279,7 +279,7 @@ export function getMessageFormatter(bundlePath: string, key: string, locale?: st
  */
 function i18n<T extends Messages>(bundle: Bundle<T>, locale?: string): Promise<T> {
 	const { bundlePath, locales, messages } = bundle;
-	const path = bundlePath.replace(/\/$/, '');
+	const path = bundlePath.replace(new RegExp(`\\${PATH_SEPARATOR}\$`), '');
 	const currentLocale = locale ? normalizeLocale(locale) : getRootLocale();
 
 	try {
@@ -305,7 +305,7 @@ function i18n<T extends Messages>(bundle: Bundle<T>, locale?: string): Promise<T
 			localeCache.set(currentLocale, <T> Object.freeze(localeMessages));
 			Globalize.loadMessages({
 				[currentLocale]: {
-					[bundlePath.replace(/\//g, '-')]: localeMessages
+					[bundlePath.replace(new RegExp(`\\${PATH_SEPARATOR}`, 'g'), '-')]: localeMessages
 				}
 			});
 

--- a/tests/support/mocks/common/main.ts
+++ b/tests/support/mocks/common/main.ts
@@ -8,8 +8,10 @@ const locales = [
 // TODO: The default loader attempts to use the native Node.js `require` when running on Node. However, the Intern
 // suite uses the @dojo/loader, in which case the context for requires is the location of the loader module; or in
 // this case, `node_modules/@dojo/loader/loader.min.js'. Is there a better, less hacky way to handle this?
-const basePath = has('host-node') ? '../_build/' : '';
-const bundlePath = basePath + 'tests/support/mocks/common/main';
+const hasHostNode = has('host-node');
+const pathSeparator = hasHostNode ? require('path').sep : '/';
+const basePath = hasHostNode ? `..${pathSeparator}_build${pathSeparator}` : '';
+const bundlePath = `${basePath}tests${pathSeparator}support${pathSeparator}mocks${pathSeparator}common${pathSeparator}main`;
 
 const messages = {
 	hello: 'Hello',

--- a/tests/support/mocks/common/party.ts
+++ b/tests/support/mocks/common/party.ts
@@ -3,8 +3,10 @@ import has from '@dojo/core/has';
 // TODO: The default loader attempts to use the native Node.js `require` when running on Node. However, the Intern
 // suite uses the @dojo/loader, in which case the context for requires is the location of the loader module; or in
 // this case, `node_modules/@dojo/loader/loader.min.js'. Is there a better, less hacky way to handle this?
-const basePath = has('host-node') ? '../_build/' : '';
-const bundlePath = basePath + 'tests/support/mocks/common/party';
+const hasHostNode = has('host-node');
+const pathSeparator = hasHostNode ? require('path').sep : '/';
+const basePath = hasHostNode ? `..${pathSeparator}_build${pathSeparator}` : '';
+const bundlePath = `${basePath}tests${pathSeparator}support${pathSeparator}mocks${pathSeparator}common${pathSeparator}party`;
 
 const messages = {
 	guestInfo: `{gender, select,


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug
**Description:** 

Uses the file system path separator where it was not being used, and escapes the windows '\' separator properly in string literals being used to build regular expressions.
**Related Issue:** #52 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged
