### PR TITLE
Use @dojo/core/Evented for locale observables.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/compose": "2.0.0-beta.23",
     "@dojo/core": "2.0.0-alpha.24",
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/shim": "2.0.0-beta.9"

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,5 @@
 /* tslint:disable:interface-name */
-import compose from '@dojo/compose/compose';
-import eventedMixin from '@dojo/compose/bases/eventedMixin';
+import Evented from '@dojo/core/Evented';
 import has from '@dojo/core/has';
 import global from '@dojo/core/global';
 import { assign } from '@dojo/core/lang';
@@ -67,7 +66,7 @@ const PATH_SEPARATOR: string = has('host-node') ? require('path').sep : '/';
 const VALID_PATH_PATTERN = new RegExp(`\\${PATH_SEPARATOR}[^\\${PATH_SEPARATOR}]+\$`);
 const bundleMap = new Map<string, Map<string, Messages>>();
 const formatterMap = new Map<string, MessageFormatter>();
-const localeProducer = compose({}).mixin(eventedMixin)();
+const localeProducer = new Evented({});
 let rootLocale: string;
 
 /**
@@ -348,8 +347,8 @@ export function invalidate(bundlePath?: string) {
 export const observeLocale = (function () {
 	const localeSource = new Observable<string>((observer: SubscriptionObserver<string>) => {
 		const handles: Handle[] = [
-			localeProducer.on('change', (event) => {
-				observer.next(event.target as string);
+			localeProducer.on('change', (event: any) => {
+				observer.next(event.target);
 			})
 		];
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: '@dojo/compose',
+	name: '@dojo/i18n',
 	fixSessionCapabilities: false
 };
 


### PR DESCRIPTION
**Description:** 

Migrate from `@dojo/compose` to `@dojo/core/Evented` for the locale
producer. Also fix a typo in the Intern config.

Resolves #57 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [ ] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged
