### PR TITLE
Hotfix: missing CLDR data on locale switch.

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -376,6 +376,11 @@ export function switchLocale(locale: string): void {
 
 	if (previous !== rootLocale) {
 		if (isLoaded('supplemental', 'likelySubtags')) {
+			Globalize.load({
+				main: {
+					[rootLocale]: {}
+				}
+			});
 			Globalize.locale(rootLocale);
 		}
 


### PR DESCRIPTION
**Type:** bug

Fixes a bug that results in an error being thrown when the locale is switched and message formatting is required. This particular bug is caused by the fact that Globalize.js requires that at least an empty object for a locale has been registered with Cldr.js (h/t @rorticus for the fix).

**Related Issue:** #59 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged
