### PR TITLE
Fix date parsing for DST dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@dojo/shim": "2.0.0-beta.10"
   },
   "dependencies": {
-    "globalize": "~1.2.2"
+    "globalize": "1.2.2"
   },
   "devDependencies": {
     "@dojo/interfaces": "2.0.0-alpha.11",


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Implements a workaround for a [Globalize.js bug](https://github.com/globalizejs/globalize/issues/689) that incorrectly parses date strings when the the parsed date is in standard time while today's date is in daylight savings time.

Resolves #66 
