### PR TITLE
Update @dojo/core to alpha.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/core": "2.0.0-alpha.25",
+    "@dojo/core": "2.0.0-alpha.26",
     "@dojo/has": "2.0.0-alpha.8",
     "@dojo/shim": "2.0.0-beta.10"
   },


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Blocked by #67. Updates the `@dojo/core` peer dependency to alpha.26.
