### PR TITLE
Move common load methods into cldr/load/default

### DIFF
--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -1,102 +1,20 @@
-// required for Globalize/Cldr to properly resolve locales in the browser.
-import 'cldrjs/dist/cldr/unresolved';
 import load from '@dojo/core/load';
 import coreRequest from '@dojo/core/request';
 import has from '@dojo/has/has';
 import { Require } from '@dojo/interfaces/loader';
 import Promise from '@dojo/shim/Promise';
-import * as Globalize from 'globalize';
-import supportedLocales from './locales';
-import { generateLocales, validateLocale } from '../util/main';
+
+import baseLoad, {
+	CldrData,
+	CldrGroup,
+	LocaleData,
+	isLoaded,
+	mainPackages,
+	reset,
+	supplementalPackages
+} from './load/default';
 
 declare const require: Require;
-
-export interface CldrData {
-	main?: LocaleData;
-	supplemental?: any;
-}
-
-export type CldrGroup = 'main' | 'supplemental';
-
-export interface LocaleData {
-	[locale: string]: any;
-}
-
-/**
- * A list of all required CLDR packages for an individual locale.
- */
-export const mainPackages = Object.freeze([
-	'dates/calendars/gregorian',
-	'dates/fields',
-	'dates/timeZoneNames',
-	'numbers',
-	'numbers/currencies',
-	'units'
-]);
-
-/**
- * A list of all required CLDR supplement packages.
- */
-export const supplementalPackages = Object.freeze([
-	'currencyData',
-	'likelySubtags',
-	'numberingSystems',
-	'plurals-type-cardinal',
-	'plurals-type-ordinal',
-	'timeData',
-	'weekData'
-]);
-
-/**
- * @private
- * A simple map containing boolean flags indicating whether a particular CLDR package has been loaded.
- */
-const loadCache = {
-	main: Object.create(null),
-	supplemental: generateSupplementalCache()
-};
-
-/**
- * @private
- * Generate the locale-specific data cache from a list of keys. Nested objects will be generated from
- * slash-separated strings.
- *
- * @param cache
- * An empty locale cache object.
- *
- * @param keys
- * The list of keys.
- */
-function generateLocaleCache(cache: any, keys: ReadonlyArray<string>) {
-	return keys.reduce((tree: any, key: string) => {
-		const parts = key.split('/');
-
-		if (parts.length === 1) {
-			tree[key] = false;
-			return tree;
-		}
-
-		parts.reduce((tree: any, key: string, i: number) => {
-			if (typeof tree[key] !== 'object') {
-				tree[key] = i === parts.length - 1 ? false : Object.create(null);
-			}
-			return tree[key];
-		}, tree);
-
-		return tree;
-	}, cache);
-}
-
-/**
- * @private
- * Generate the supplemental data cache.
- */
-function generateSupplementalCache() {
-	return supplementalPackages.reduce((map: any, key: string) => {
-		map[key] = false;
-		return map;
-	}, Object.create(null));
-}
 
 /**
  * @private
@@ -131,134 +49,6 @@ const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
 })();
 
 /**
- * @private
- * Recursively determine whether a list of packages have been loaded for the specified CLDR group.
- *
- * @param group
- * The CLDR group object (e.g., the supplemental data, or a specific locale group)
- *
- * @param args
- * A list of keys to recursively check from left to right. For example, if [ "en", "numbers" ],
- * then `group.en.numbers` must exist for the test to pass.
- *
- * @return
- * `true` if the deepest value exists; `false` otherwise.
- */
-function isLoadedForGroup(group: any, args: string[]) {
-	return args.every((arg: string) => {
-		const next = group[arg];
-		group = next;
-		return Boolean(next);
-	});
-}
-
-/**
- * @private
- * Recursively flag as loaded all recognized keys on the provided CLDR data object.
- *
- * @param cache
- * The load cache (either the entire object, or a nested segment of it).
- *
- * @param localeData
- * The CLDR data object being loaded (either the entire object, or a nested segment of it).
- */
-function registerLocaleData(cache: any, localeData: any) {
-	Object.keys(localeData).forEach((key: string) => {
-		if (key in cache) {
-			const value = cache[key];
-
-			if (typeof value === 'boolean') {
-				cache[key] = true;
-			}
-			else {
-				registerLocaleData(value, localeData[key]);
-			}
-		}
-	});
-}
-
-/**
- * @private
- * Flag all supplied CLDR packages for a specific locale as loaded.
- *
- * @param data
- * The `main` locale data.
- */
-function registerMain(data?: LocaleData) {
-	if (!data) {
-		return;
-	}
-
-	Object.keys(data).forEach((locale: string) => {
-		if (supportedLocales.indexOf(locale) < 0) {
-			return;
-		}
-
-		let loadedData = loadCache.main[locale];
-		if (!loadedData) {
-			loadedData = loadCache.main[locale] = generateLocaleCache(Object.create(null), mainPackages);
-		}
-
-		registerLocaleData(loadedData, data[locale]);
-	});
-}
-
-/**
- * @private
- * Flag all supplied CLDR supplemental packages as loaded.
- *
- * @param data
- * The supplemental data.
- */
-function registerSupplemental(data?: any) {
-	if (!data) {
-		return;
-	}
-
-	const supplemental = loadCache.supplemental;
-	Object.keys(data).forEach((key: string) => {
-		if (key in supplemental) {
-			supplemental[key] = true;
-		}
-	});
-}
-
-/**
- * Determine whether a particular CLDR package has been loaded.
- *
- * Example: to check that `supplemental.likelySubtags` has been loaded, `isLoaded` would be called as
- * `isLoaded('supplemental', 'likelySubtags')`.
- *
- * @param groupName
- * The group to check; either "main" or "supplemental".
- *
- * @param ...args
- * Any remaining keys in the path to the desired package.
- *
- * @return
- * `true` if the deepest value exists; `false` otherwise.
- */
-export function isLoaded(groupName: CldrGroup, ...args: string[]) {
-	let group: any = loadCache[groupName];
-
-	if (groupName === 'main' && args.length > 0) {
-		const locale = args[0];
-
-		if (!validateLocale(locale)) {
-			return false;
-		}
-
-		args = args.slice(1);
-		return generateLocales(locale).some((locale: string) => {
-			const next = group[locale];
-			return next ? isLoadedForGroup(next, args) : false;
-		});
-	}
-
-	return isLoadedForGroup(group, args);
-}
-
-/**
  * Load the specified CLDR data with the i18n ecosystem.
  *
  * @param data
@@ -271,30 +61,21 @@ export function isLoaded(groupName: CldrGroup, ...args: string[]) {
 export default function loadCldrData(data: CldrData | string[]): Promise<void> {
 	if (Array.isArray(data)) {
 		return getJson(data).then((result: CldrData[]) => {
-			result.forEach(loadCldrData);
+			result.forEach(baseLoad);
 		});
 	}
 
-	registerMain(data.main);
-	registerSupplemental(data.supplemental);
-	Globalize.load(data);
+	baseLoad(data);
 
 	return Promise.resolve();
 }
 
-/**
- * Clear the load cache, either the entire cache for the specified group. After calling this method,
- * `isLoaded` will return false for keys within the specified group(s).
- *
- * @param group
- * An optional group name. If not provided, then both the "main" and "supplemental" caches will be cleared.
- */
-export function reset(group?: CldrGroup) {
-	if (group !== 'supplemental') {
-		loadCache.main = Object.create(null);
-	}
-
-	if (group !== 'main') {
-		loadCache.supplemental = generateSupplementalCache();
-	}
+export {
+	CldrData,
+	CldrGroup,
+	LocaleData,
+	isLoaded,
+	mainPackages,
+	reset,
+	supplementalPackages
 }

--- a/src/cldr/load/default.ts
+++ b/src/cldr/load/default.ts
@@ -1,0 +1,249 @@
+// required for Globalize/Cldr to properly resolve locales in the browser.
+import 'cldrjs/dist/cldr/unresolved';
+import * as Globalize from 'globalize';
+import supportedLocales from '../locales';
+import { generateLocales, validateLocale } from '../../util/main';
+
+export interface CldrData {
+	main?: LocaleData;
+	supplemental?: any;
+}
+
+export type CldrGroup = 'main' | 'supplemental';
+
+export interface LocaleData {
+	[locale: string]: any;
+}
+
+/**
+ * A list of all required CLDR packages for an individual locale.
+ */
+export const mainPackages = Object.freeze([
+	'dates/calendars/gregorian',
+	'dates/fields',
+	'dates/timeZoneNames',
+	'numbers',
+	'numbers/currencies',
+	'units'
+]);
+
+/**
+ * A list of all required CLDR supplement packages.
+ */
+export const supplementalPackages = Object.freeze([
+	'currencyData',
+	'likelySubtags',
+	'numberingSystems',
+	'plurals-type-cardinal',
+	'plurals-type-ordinal',
+	'timeData',
+	'weekData'
+]);
+
+/**
+ * @private
+ * A simple map containing boolean flags indicating whether a particular CLDR package has been loaded.
+ */
+const loadCache = {
+	main: Object.create(null),
+	supplemental: generateSupplementalCache()
+};
+
+/**
+ * @private
+ * Generate the locale-specific data cache from a list of keys. Nested objects will be generated from
+ * slash-separated strings.
+ *
+ * @param cache
+ * An empty locale cache object.
+ *
+ * @param keys
+ * The list of keys.
+ */
+function generateLocaleCache(cache: any, keys: ReadonlyArray<string>) {
+	return keys.reduce((tree: any, key: string) => {
+		const parts = key.split('/');
+
+		if (parts.length === 1) {
+			tree[key] = false;
+			return tree;
+		}
+
+		parts.reduce((tree: any, key: string, i: number) => {
+			if (typeof tree[key] !== 'object') {
+				tree[key] = i === parts.length - 1 ? false : Object.create(null);
+			}
+			return tree[key];
+		}, tree);
+
+		return tree;
+	}, cache);
+}
+
+/**
+ * @private
+ * Generate the supplemental data cache.
+ */
+function generateSupplementalCache() {
+	return supplementalPackages.reduce((map: any, key: string) => {
+		map[key] = false;
+		return map;
+	}, Object.create(null));
+}
+
+/**
+ * @private
+ * Recursively determine whether a list of packages have been loaded for the specified CLDR group.
+ *
+ * @param group
+ * The CLDR group object (e.g., the supplemental data, or a specific locale group)
+ *
+ * @param args
+ * A list of keys to recursively check from left to right. For example, if [ "en", "numbers" ],
+ * then `group.en.numbers` must exist for the test to pass.
+ *
+ * @return
+ * `true` if the deepest value exists; `false` otherwise.
+ */
+function isLoadedForGroup(group: any, args: string[]) {
+	return args.every((arg: string) => {
+		const next = group[arg];
+		group = next;
+		return Boolean(next);
+	});
+}
+
+/**
+ * @private
+ * Recursively flag as loaded all recognized keys on the provided CLDR data object.
+ *
+ * @param cache
+ * The load cache (either the entire object, or a nested segment of it).
+ *
+ * @param localeData
+ * The CLDR data object being loaded (either the entire object, or a nested segment of it).
+ */
+function registerLocaleData(cache: any, localeData: any) {
+	Object.keys(localeData).forEach((key: string) => {
+		if (key in cache) {
+			const value = cache[key];
+
+			if (typeof value === 'boolean') {
+				cache[key] = true;
+			}
+			else {
+				registerLocaleData(value, localeData[key]);
+			}
+		}
+	});
+}
+
+/**
+ * @private
+ * Flag all supplied CLDR packages for a specific locale as loaded.
+ *
+ * @param data
+ * The `main` locale data.
+ */
+function registerMain(data?: LocaleData) {
+	if (!data) {
+		return;
+	}
+
+	Object.keys(data).forEach((locale: string) => {
+		if (supportedLocales.indexOf(locale) < 0) {
+			return;
+		}
+
+		let loadedData = loadCache.main[locale];
+		if (!loadedData) {
+			loadedData = loadCache.main[locale] = generateLocaleCache(Object.create(null), mainPackages);
+		}
+
+		registerLocaleData(loadedData, data[locale]);
+	});
+}
+
+/**
+ * @private
+ * Flag all supplied CLDR supplemental packages as loaded.
+ *
+ * @param data
+ * The supplemental data.
+ */
+function registerSupplemental(data?: any) {
+	if (!data) {
+		return;
+	}
+
+	const supplemental = loadCache.supplemental;
+	Object.keys(data).forEach((key: string) => {
+		if (key in supplemental) {
+			supplemental[key] = true;
+		}
+	});
+}
+
+/**
+ * Determine whether a particular CLDR package has been loaded.
+ *
+ * Example: to check that `supplemental.likelySubtags` has been loaded, `isLoaded` would be called as
+ * `isLoaded('supplemental', 'likelySubtags')`.
+ *
+ * @param groupName
+ * The group to check; either "main" or "supplemental".
+ *
+ * @param ...args
+ * Any remaining keys in the path to the desired package.
+ *
+ * @return
+ * `true` if the deepest value exists; `false` otherwise.
+ */
+export function isLoaded(groupName: CldrGroup, ...args: string[]) {
+	let group: any = loadCache[groupName];
+
+	if (groupName === 'main' && args.length > 0) {
+		const locale = args[0];
+
+		if (!validateLocale(locale)) {
+			return false;
+		}
+
+		args = args.slice(1);
+		return generateLocales(locale).some((locale: string) => {
+			const next = group[locale];
+			return next ? isLoadedForGroup(next, args) : false;
+		});
+	}
+
+	return isLoadedForGroup(group, args);
+}
+
+/**
+ * Load the specified CLDR data with the i18n ecosystem.
+ *
+ * @param data
+ * A data object containing `main` and/or `supplemental` objects with CLDR data.
+ */
+export default function loadCldrData(data: CldrData) {
+	registerMain(data.main);
+	registerSupplemental(data.supplemental);
+	Globalize.load(data);
+}
+
+/**
+ * Clear the load cache, either the entire cache for the specified group. After calling this method,
+ * `isLoaded` will return false for keys within the specified group(s).
+ *
+ * @param group
+ * An optional group name. If not provided, then both the "main" and "supplemental" caches will be cleared.
+ */
+export function reset(group?: CldrGroup) {
+	if (group !== 'supplemental') {
+		loadCache.main = Object.create(null);
+	}
+
+	if (group !== 'main') {
+		loadCache.supplemental = generateSupplementalCache();
+	}
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,4 +1,5 @@
 import './cldr/load';
+import './cldr/load/default';
 import './cldr/load/webpack';
 import './date';
 import './i18n';

--- a/tests/unit/cldr/load.ts
+++ b/tests/unit/cldr/load.ts
@@ -6,6 +6,12 @@ import loadCldrData, {
 	reset,
 	supplementalPackages
 } from '../../../src/cldr/load';
+import {
+	isLoaded as utilIsLoaded,
+	mainPackages as utilMainPackages,
+	reset as utilReset,
+	supplementalPackages as utilSupplementalPackages
+} from '../../../src/cldr/load/default';
 
 registerSuite({
 	name: 'cldr/load',
@@ -14,71 +20,11 @@ registerSuite({
 		reset();
 	},
 
-	mainPackages() {
-		assert.isTrue(Object.isFrozen(mainPackages), 'Should be frozen.');
-		assert.sameMembers(mainPackages as any[], [
-			'dates/calendars/gregorian',
-			'dates/fields',
-			'dates/timeZoneNames',
-			'numbers',
-			'numbers/currencies',
-			'units'
-		]);
-	},
-
-	supplementalPackages() {
-		assert.isTrue(Object.isFrozen(supplementalPackages), 'Should be frozen.');
-		assert.sameMembers(supplementalPackages as any[], [
-			'currencyData',
-			'likelySubtags',
-			'numberingSystems',
-			'plurals-type-cardinal',
-			'plurals-type-ordinal',
-			'timeData',
-			'weekData'
-		]);
-	},
-
-	isLoaded: {
-		'with an unloaded package'() {
-			assert.isFalse(isLoaded('supplemental', 'likelySubtags'));
-			assert.isFalse(isLoaded('main', 'en'));
-		},
-
-		'with loaded pacakges'() {
-			loadCldrData({
-				main: {
-					zh: {
-						numbers: {}
-					}
-				},
-
-				supplemental: {
-					likelySubtags: {}
-				}
-			});
-
-			assert.isTrue(isLoaded('main'));
-			assert.isTrue(isLoaded('supplemental'));
-			assert.isTrue(isLoaded('main', 'zh'));
-			assert.isTrue(isLoaded('main', 'zh-MO'));
-			assert.isTrue(isLoaded('main', 'zh', 'numbers'));
-			assert.isTrue(isLoaded('supplemental', 'likelySubtags'));
-		},
-
-		'with unknown packages'() {
-			loadCldrData({
-				main: {
-					arbitrary: {}
-				},
-				supplemental: {
-					arbitrary: {}
-				}
-			});
-
-			assert.isFalse(isLoaded('main', 'arbitrary'), 'Unknown locale packages are ignored.');
-			assert.isFalse(isLoaded('supplemental', 'arbitrary'), 'Unknown supplemental packages are ignored.');
-		}
+	api() {
+		assert.strictEqual(isLoaded, utilIsLoaded, 'isLoaded should be re-exported');
+		assert.strictEqual(mainPackages, utilMainPackages, 'mainPackages should be re-exported');
+		assert.strictEqual(reset, utilReset, 'reset should be re-exported');
+		assert.strictEqual(supplementalPackages, utilSupplementalPackages, 'supplementalPackages should be re-exported');
 	},
 
 	loadCldrData: {
@@ -100,51 +46,6 @@ registerSuite({
 			}).then(() => {
 				assert.isTrue(isLoaded('supplemental', 'likelySubtags'));
 			});
-		}
-	},
-
-	reset: {
-		beforeEach() {
-			loadCldrData({
-				main: {
-					zh: {
-						numbers: {}
-					}
-				},
-
-				supplemental: {
-					likelySubtags: {}
-				}
-			});
-		},
-
-		'main only'() {
-			reset('main');
-
-			assert.isFalse(isLoaded('main', 'zh'), '"main" data should be cleared.');
-			assert.isFalse(isLoaded('main', 'zh-MO'), '"main" data should be cleared.');
-			assert.isFalse(isLoaded('main', 'zh', 'numbers'), '"main" data should be cleared.');
-
-			assert.isTrue(isLoaded('supplemental', 'likelySubtags'), '"supplemental" data should not be cleared.');
-		},
-
-		'supplemental only'() {
-			reset('supplemental');
-
-			assert.isTrue(isLoaded('main', 'zh'));
-			assert.isTrue(isLoaded('main', 'zh-MO'));
-			assert.isTrue(isLoaded('main', 'zh', 'numbers'));
-
-			assert.isFalse(isLoaded('supplemental', 'likelySubtags'), '"supplemental" data should be cleared.');
-		},
-
-		'both main and supplmental'() {
-			reset();
-
-			assert.isFalse(isLoaded('main', 'zh'));
-			assert.isFalse(isLoaded('main', 'zh-MO'));
-			assert.isFalse(isLoaded('main', 'zh', 'numbers'));
-			assert.isFalse(isLoaded('supplemental', 'likelySubtags'));
 		}
 	}
 });

--- a/tests/unit/cldr/load/default.ts
+++ b/tests/unit/cldr/load/default.ts
@@ -1,0 +1,140 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import baseLoad, {
+	isLoaded,
+	mainPackages,
+	reset,
+	supplementalPackages
+} from '../../../../src/cldr/load/default';
+
+registerSuite({
+	name: 'cldr/load/default',
+
+	afterEach() {
+		reset();
+	},
+
+	mainPackages() {
+		assert.isTrue(Object.isFrozen(mainPackages), 'Should be frozen.');
+		assert.sameMembers(mainPackages as any[], [
+			'dates/calendars/gregorian',
+			'dates/fields',
+			'dates/timeZoneNames',
+			'numbers',
+			'numbers/currencies',
+			'units'
+		]);
+	},
+
+	supplementalPackages() {
+		assert.isTrue(Object.isFrozen(supplementalPackages), 'Should be frozen.');
+		assert.sameMembers(supplementalPackages as any[], [
+			'currencyData',
+			'likelySubtags',
+			'numberingSystems',
+			'plurals-type-cardinal',
+			'plurals-type-ordinal',
+			'timeData',
+			'weekData'
+		]);
+	},
+
+	isLoaded: {
+		'with an unloaded package'() {
+			assert.isFalse(isLoaded('supplemental', 'likelySubtags'));
+			assert.isFalse(isLoaded('main', 'en'));
+		},
+
+		'with loaded pacakges'() {
+			baseLoad({
+				main: {
+					zh: {
+						numbers: {}
+					}
+				},
+
+				supplemental: {
+					likelySubtags: {}
+				}
+			});
+
+			assert.isTrue(isLoaded('main'));
+			assert.isTrue(isLoaded('supplemental'));
+			assert.isTrue(isLoaded('main', 'zh'));
+			assert.isTrue(isLoaded('main', 'zh-MO'));
+			assert.isTrue(isLoaded('main', 'zh', 'numbers'));
+			assert.isTrue(isLoaded('supplemental', 'likelySubtags'));
+		},
+
+		'with unknown packages'() {
+			baseLoad({
+				main: {
+					arbitrary: {}
+				},
+				supplemental: {
+					arbitrary: {}
+				}
+			});
+
+			assert.isFalse(isLoaded('main', 'arbitrary'), 'Unknown locale packages are ignored.');
+			assert.isFalse(isLoaded('supplemental', 'arbitrary'), 'Unknown supplemental packages are ignored.');
+		}
+	},
+
+	baseLoad() {
+		assert.isFalse(isLoaded('supplemental', 'likelySubtags'));
+
+		baseLoad({
+			supplemental: {
+				likelySubtags: {}
+			}
+		});
+
+		assert.isTrue(isLoaded('supplemental', 'likelySubtags'));
+	},
+
+	reset: {
+		beforeEach() {
+			baseLoad({
+				main: {
+					zh: {
+						numbers: {}
+					}
+				},
+
+				supplemental: {
+					likelySubtags: {}
+				}
+			});
+		},
+
+		'main only'() {
+			reset('main');
+
+			assert.isFalse(isLoaded('main', 'zh'), '"main" data should be cleared.');
+			assert.isFalse(isLoaded('main', 'zh-MO'), '"main" data should be cleared.');
+			assert.isFalse(isLoaded('main', 'zh', 'numbers'), '"main" data should be cleared.');
+
+			assert.isTrue(isLoaded('supplemental', 'likelySubtags'), '"supplemental" data should not be cleared.');
+		},
+
+		'supplemental only'() {
+			reset('supplemental');
+
+			assert.isTrue(isLoaded('main', 'zh'));
+			assert.isTrue(isLoaded('main', 'zh-MO'));
+			assert.isTrue(isLoaded('main', 'zh', 'numbers'));
+
+			assert.isFalse(isLoaded('supplemental', 'likelySubtags'), '"supplemental" data should be cleared.');
+		},
+
+		'both main and supplmental'() {
+			reset();
+
+			assert.isFalse(isLoaded('main', 'zh'));
+			assert.isFalse(isLoaded('main', 'zh-MO'));
+			assert.isFalse(isLoaded('main', 'zh', 'numbers'));
+			assert.isFalse(isLoaded('supplemental', 'likelySubtags'));
+		}
+	}
+});

--- a/tests/unit/cldr/load/webpack.ts
+++ b/tests/unit/cldr/load/webpack.ts
@@ -1,7 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import global from '@dojo/core/global';
-import * as coreLoad from '../../../../src/cldr/load';
 import loadCldrData, {
 	CldrData,
 	isLoaded,
@@ -9,6 +8,11 @@ import loadCldrData, {
 	reset,
 	supplementalPackages
 } from '../../../../src/cldr/load/webpack';
+import {
+	mainPackages as utilMainPackages,
+	reset as utilReset,
+	supplementalPackages as utilSupplementalPackages
+} from '../../../../src/cldr/load/default';
 
 let cldrData: CldrData | null;
 
@@ -39,8 +43,9 @@ registerSuite({
 	},
 
 	api() {
-		assert.strictEqual(mainPackages, coreLoad.mainPackages);
-		assert.strictEqual(supplementalPackages, coreLoad.supplementalPackages);
+		assert.strictEqual(mainPackages, utilMainPackages, 'mainPackages should be re-exported');
+		assert.strictEqual(reset, utilReset, 'reset should be re-exported');
+		assert.strictEqual(supplementalPackages, utilSupplementalPackages, 'supplementalPackages should be re-exported');
 	},
 
 	isLoaded() {

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -22,6 +22,13 @@ import partyBundle from '../support/mocks/common/party';
 registerSuite({
 	name: 'i18n',
 
+	setup() {
+		// Load the CLDR data for the locales used in the tests ('en' and 'fr');
+		return fetchCldrData([ 'en', 'fr' ]).then(() => {
+			switchLocale('en');
+		});
+	},
+
 	afterEach() {
 		const loadCldrData = <any> cldrLoad.default;
 		if (typeof loadCldrData.restore === 'function') {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Blocked by #67 (failing tests). `cldr/load/webpack` no longer includes the values imported from `cldr/load` in webpack builds. Separating the common methods between the two into a shared module circumvents this issue. To preserve the existing API, exports from `cldr/load/default` are re-exported by both `cldr/load` and `cldr/load/webpack`.

Resolves #65 
