### PR TITLE
Update Globalize.js to 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@dojo/shim": "2.0.0-beta.10"
   },
   "dependencies": {
-    "globalize": "1.2.2"
+    "globalize": "^1.2.3"
   },
   "devDependencies": {
     "@dojo/interfaces": "2.0.0-alpha.11",

--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -58,16 +58,14 @@ const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
  * @return
  * A promise that resolves once all data have been loaded and registered.
  */
-export default function loadCldrData(data: CldrData | string[]): Promise<void> {
+export default function loadCldrData(data: CldrData | string[]) {
 	if (Array.isArray(data)) {
 		return getJson(data).then((result: CldrData[]) => {
 			result.forEach(baseLoad);
 		});
 	}
 
-	baseLoad(data);
-
-	return Promise.resolve();
+	return baseLoad(data);
 }
 
 export {

--- a/src/cldr/load/default.ts
+++ b/src/cldr/load/default.ts
@@ -1,5 +1,6 @@
 // required for Globalize/Cldr to properly resolve locales in the browser.
 import 'cldrjs/dist/cldr/unresolved';
+import Promise from '@dojo/shim/Promise';
 import * as Globalize from 'globalize';
 import supportedLocales from '../locales';
 import { generateLocales, validateLocale } from '../../util/main';
@@ -225,10 +226,11 @@ export function isLoaded(groupName: CldrGroup, ...args: string[]) {
  * @param data
  * A data object containing `main` and/or `supplemental` objects with CLDR data.
  */
-export default function loadCldrData(data: CldrData) {
+export default function loadCldrData(data: CldrData): Promise<void> {
 	registerMain(data.main);
 	registerSupplemental(data.supplemental);
 	Globalize.load(data);
+	return Promise.resolve();
 }
 
 /**

--- a/src/cldr/load/webpack.ts
+++ b/src/cldr/load/webpack.ts
@@ -31,8 +31,7 @@ export default function loadCldrData(data: CldrData | string[]): P<void> {
 	}
 
 	loadInjectedData();
-	baseLoad(data);
-	return P.resolve();
+	return baseLoad(data);
 }
 
 /**

--- a/src/cldr/load/webpack.ts
+++ b/src/cldr/load/webpack.ts
@@ -6,7 +6,7 @@ import baseLoad, {
 	mainPackages,
 	reset,
 	supplementalPackages
-} from '../load';
+} from './default';
 
 declare const __cldrData__: CldrData;
 
@@ -31,7 +31,8 @@ export default function loadCldrData(data: CldrData | string[]): P<void> {
 	}
 
 	loadInjectedData();
-	return baseLoad(data);
+	baseLoad(data);
+	return P.resolve();
 }
 
 /**

--- a/src/date.ts
+++ b/src/date.ts
@@ -52,27 +52,6 @@ export type RelativeTimeFormatterOptions = {
 	form?: RelativeTimeLength;
 }
 
-// Globalize.js incorrectly handles timezone offsets when parsing date strings.
-// This is resolved with https://github.com/globalizejs/globalize/pull/693, and
-// will be included with the next release. Until then, the following workaround
-// is needed.
-const TODAY_OFFSET = new Date().getTimezoneOffset();
-function fixParsedDate(date: Date, optionsOrLocale?: DateFormatterOptions | string): Date {
-	if (!date || !optionsOrLocale || typeof optionsOrLocale === 'string') {
-		return date;
-	}
-
-	const offset = date.getTimezoneOffset();
-	const { datetime } = optionsOrLocale;
-
-	if (offset === TODAY_OFFSET || (datetime !== 'long' && datetime !== 'full')) {
-		return date;
-	}
-
-	date.setMinutes(date.getMinutes() - (offset - TODAY_OFFSET));
-	return date;
-}
-
 /**
  * Format a date according to the specified options for the specified or current locale.
  *
@@ -163,14 +142,10 @@ export function getDateFormatter(optionsOrLocale?: DateFormatterOptions | string
 export function getDateParser(options?: DateFormatterOptions, locale?: string): DateParser;
 export function getDateParser(locale?: string): DateParser;
 export function getDateParser(optionsOrLocale?: DateFormatterOptions | string, locale?: string): DateParser {
-	const parser = globalizeDelegator<DateFormatterOptions, DateParser>('dateParser', {
+	return globalizeDelegator<DateFormatterOptions, DateParser>('dateParser', {
 		locale,
 		optionsOrLocale
 	});
-
-	return function (dateString: string): Date {
-		return fixParsedDate(parser(dateString), optionsOrLocale);
-	};
 }
 
 /**
@@ -218,11 +193,9 @@ export function getRelativeTimeFormatter(unit: string, optionsOrLocale?: Relativ
 export function parseDate(value: string, options?: DateFormatterOptions, locale?: string): Date;
 export function parseDate(value: string, locale?: string): Date;
 export function parseDate(value: string, optionsOrLocale?: DateFormatterOptions | string, locale?: string): Date {
-	const date = globalizeDelegator<string, DateFormatterOptions, Date>('parseDate', {
+	return globalizeDelegator<string, DateFormatterOptions, Date>('parseDate', {
 		locale,
 		optionsOrLocale,
 		value
 	});
-
-	return fixParsedDate(date, optionsOrLocale);
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Update Globalize.js to 1.2.3, which includes a date parser fix that makes a workaround in date.ts obsolete.

Resolves #71 
