### PR TITLE
Allow locale messages to be manually injected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ i18n(bundle, 'fr').then(function (messages: Messages) {
 
 If an unsupported locale is passed to `i18n`, then the default messages are returned. Further, any messages not provided by the locale-specific bundle will also fall back to their defaults. As such, the default bundle should contain _all_ message keys used by any of the locale-specific bundles.
 
+Alternatively, locale messages can be manually loaded by passing them to `setLocaleMessages`. This is useful for pre-caching locale-specific messages so that an additional HTTP request is not sent to load them. Locale-specific messages are merged with the default messages, so partial message bundles are acceptable:
+
+```
+const partialMessages = { hello: 'Ahoj' };
+setLocaleMessages(bundle, partialMessages, 'cz');
+
+i18n(bundle, 'cz').then((messages) => {
+	console.log(messages.hello); // "Ahoj"
+	console.log(messages.goodbye); // "Goodbye" (defaults are used when not overridden)
+});
+```
+
 Once locale dictionaries for a bundle have been loaded, they are cached and can be accessed synchronously via `getCachedMessages`:
 
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import i18n, {
 	invalidate,
 	MessageFormatter,
 	Messages,
+	setLocaleMessages,
 	switchLocale,
 	systemLocale
 } from './i18n';
@@ -96,6 +97,7 @@ export {
 	RelativeTimeFormatterOptions,
 	RelativeTimeLength,
 	RoundNumberOption,
+	setLocaleMessages,
 	switchLocale,
 	systemLocale,
 	UnitFormatterOptions,

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -24,6 +24,7 @@ import i18n, {
 	parseDate,
 	parseNumber,
 	pluralize,
+	setLocaleMessages,
 	switchLocale,
 	systemLocale
 } from '../../src/main';
@@ -56,6 +57,7 @@ registerSuite({
 		assert.isFunction(parseDate, 'parseDate is exported.');
 		assert.isFunction(parseNumber, 'parseNumber is exported.');
 		assert.isFunction(pluralize, 'pluralize is exported.');
+		assert.isFunction(setLocaleMessages, 'setLocaleMessages is exported.');
 		assert.isFunction(switchLocale, 'switchLocale is exported.');
 		assert.isString(systemLocale, 'systemLocale is exported.');
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Implement a `setLocaleMessages` method that allows locale-specific messages for a bundle to be pre-loaded into the i18n system.

Resolves #74 