### PR TITLE
Allow context require to be passed to cldr/load.

### DIFF
--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -20,20 +20,23 @@ declare const require: Require;
  * @private
  * Load the CLDR JSON files at the specified paths.
  *
- * @param {paths}
+ * @param require
+ * An optional contextual require that can be used to resolve relative paths.
+ *
+ * @param paths
  * The JSON paths.
  *
  * @return
  * A promise to the CLDR data for each path.
  */
-const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
+const getJson: (require: any, paths: string[]) => Promise<CldrData[]> = (function () {
 	if (has('host-node')) {
-		return function (paths: string[]): Promise<{}[]> {
+		return function (require: any, paths: string[]): Promise<{}[]> {
 			return load(require, ...paths);
 		};
 	}
 
-	return function (paths: string[]): Promise<CldrData[]> {
+	return function (require: any, paths: string[]): Promise<CldrData[]> {
 		return Promise.all(paths.map((path: string): Promise<CldrData> => {
 			if (typeof require.toUrl === 'function') {
 				path = require.toUrl(path);
@@ -51,6 +54,9 @@ const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
 /**
  * Load the specified CLDR data with the i18n ecosystem.
  *
+ * @param contextRequire
+ * An optional contextual require that can be used to resolve relative paths.
+ *
  * @param data
  * Either a data object to load directly, or an array of URLs to CLDR data objects. Note that the response for
  * dynamically-loaded data must satisfy the `CldrData` interface.
@@ -58,14 +64,19 @@ const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
  * @return
  * A promise that resolves once all data have been loaded and registered.
  */
-export default function loadCldrData(data: CldrData | string[]) {
+export default function loadCldrData(contextRequire: Function, data: CldrData | string[]): Promise<void>;
+export default function loadCldrData(data: CldrData | string[]): Promise<void>;
+export default function loadCldrData(dataOrRequire: Function | CldrData | string[], data?: CldrData | string[]): Promise<void> {
+	const contextRequire = typeof dataOrRequire === 'function' ? dataOrRequire : require;
+	data = typeof dataOrRequire === 'function' ? data : dataOrRequire;
+
 	if (Array.isArray(data)) {
-		return getJson(data).then((result: CldrData[]) => {
+		return getJson(contextRequire, data).then((result: CldrData[]) => {
 			result.forEach(baseLoad);
 		});
 	}
 
-	return baseLoad(data);
+	return baseLoad(data as CldrData);
 }
 
 export {

--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -21,7 +21,7 @@ declare const require: Require;
  * Load the CLDR JSON files at the specified paths.
  *
  * @param require
- * An optional contextual require that can be used to resolve relative paths.
+ * The require method used to resolve relative paths.
  *
  * @param paths
  * The JSON paths.

--- a/src/cldr/load/webpack.ts
+++ b/src/cldr/load/webpack.ts
@@ -25,13 +25,17 @@ async function loadInjectedData() {
 /**
  * A webpack-specific function used to load CLDR data from a preset cache.
  */
-export default function loadCldrData(data: CldrData | string[]): P<void> {
+export default function loadCldrData(contextRequire: Function, data: CldrData | string[]): P<void>;
+export default function loadCldrData(data: CldrData | string[]): P<void>;
+export default function loadCldrData(dataOrRequire: Function | CldrData | string[], data?: CldrData | string[]): P<void> {
+	data = typeof dataOrRequire === 'function' ? data : dataOrRequire;
+
 	if (Array.isArray(data)) {
 		return P.resolve();
 	}
 
 	loadInjectedData();
-	return baseLoad(data);
+	return baseLoad(data as CldrData);
 }
 
 /**

--- a/tests/unit/cldr/load.ts
+++ b/tests/unit/cldr/load.ts
@@ -1,5 +1,7 @@
+import has from '@dojo/has/has';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import loadCldrData, {
 	isLoaded,
 	mainPackages,
@@ -45,6 +47,26 @@ registerSuite({
 				}
 			}).then(() => {
 				assert.isTrue(isLoaded('supplemental', 'likelySubtags'));
+			});
+		},
+
+		'with a require function'() {
+			assert.isFalse(isLoaded('supplemental', 'likelySubtags'));
+
+			const path = 'cldr-data/supplemental/likelySubtags.json';
+
+			if (has('host-browser')) {
+				sinon.spy(require, 'toUrl');
+			}
+
+			return loadCldrData(require, [ path ]).then(() => {
+				if (has('host-browser')) {
+					assert.isTrue((<any> require).toUrl.calledWith(path));
+					(<any> require).toUrl.restore();
+				}
+				assert.isTrue(isLoaded('supplemental', 'likelySubtags'));
+			}, () => {
+				has('host-browser') && (<any> require).toUrl.restore();
 			});
 		}
 	}

--- a/tests/unit/cldr/load/webpack.ts
+++ b/tests/unit/cldr/load/webpack.ts
@@ -72,6 +72,16 @@ registerSuite({
 			}).then(() => {
 				assert.isTrue(isLoaded('main', 'tzm'), 'CLDR data objects should be loaded.');
 			});
+		},
+
+		'with a require function'() {
+			return loadCldrData(() => {}, {
+				main: {
+					af: {}
+				}
+			}).then(() => {
+				assert.isTrue(isLoaded('main', 'af'), 'Require functions should be ignored.');
+			});
 		}
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Update `cldr/load.default` to accept a context require function as its first argument in order to properly resolve relative CLDR paths in an AMD environment.

Blocked by dojo/cli-build#122
Resolves #83 
