### PR TITLE
Allow messages to be formatted without CLDR data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ loadCldrData([
 For ICU message formatting:
 
 * `supplemental/likelySubtags`
+* `supplemental/plurals`
 
 For date/time formatting:
 
@@ -231,11 +232,39 @@ For unit formatting:
 * `supplemental/ordinals`
 * `supplemental/plurals`
 
-### ICU Message Formatting
+### Message Formatting
+
+The `i18n` module exposes two methods that handle message formatting: 1) `formatMessage`, which directly returns a formatted message based on its inputs, and 2) `getMessageFormatter`, which returns a method dedicated to formatting a single message.
+
+`@dojo/i18n` supports the ICU message format (see below), but that requires CLDR data and is not something that every application requires. As such, if the `supplemental/likeSubtags` and `supplemental/plurals` data are not loaded, then both `formatMessage` and `getMessageFormatter` will perform simple token replacement. For example, given the `guestInfo` message `{host} invites {guest} to the party.`, an object with `host` and `guest` properties can be provided to a formatter without the need to load CLDR data:
+
+```typescript
+import i18n, { formatMessage, getMessageFormatter } from '@dojo/i18n/i18n';
+import bundle from 'nls/main';
+
+i18n(bundle, 'en').then(() => {
+	const formatter = getMessageFormatter(bundle.bundlePath, 'guestInfo', 'en');
+	let message = formatter({
+		host: 'Margaret Mead',
+		guest: 'Laura Nader'
+	});
+	console.log(message); // "Margaret Mead invites Laura Nader to the party."
+
+	// Note that `formatMessage` is essentially a convenience wrapper around `getMessageFormatter`.
+	message = formatMessage(bundle.bundlePath, 'guestInfo', {
+		host: 'Marshall Sahlins',
+		gender: 'male',
+		guest: 'Bronisław Malinowski'
+	}, 'en');
+	console.log(message); // "Marshall Sahlins invites Bronisław Malinowski to the party."
+});
+```
+
+#### ICU Message Formatting
 
 **Note**: This feature requires CLDR data (see above).
 
-`@dojo/i18n` relies on [Globalize.js](https://github.com/jquery/globalize/blob/master/doc/api/message/message-formatter.md) for [ICU message formatting](http://userguide.icu-project.org/formatparse/messages), and as such all of the features offered by Globalize.js are available through `@dojo/i18n`. The `i18n` module exposes two methods that handle message formatting: 1) `formatMessage`, which directly returns a formatted message based on its inputs, and 2) `getMessageFormatter`, which returns a method dedicated to formatting a single message.
+`@dojo/i18n` relies on [Globalize.js](https://github.com/jquery/globalize/blob/master/doc/api/message/message-formatter.md) for [ICU message formatting](http://userguide.icu-project.org/formatparse/messages), and as such all of the features offered by Globalize.js are available through `@dojo/i18n`.
 
 As an example, suppose there is a locale bundle with a `guestInfo` message:
 

--- a/tests/support/mocks/common/party.ts
+++ b/tests/support/mocks/common/party.ts
@@ -9,6 +9,7 @@ const basePath = hasHostNode ? `..${pathSeparator}_build${pathSeparator}` : '';
 const bundlePath = `${basePath}tests${pathSeparator}support${pathSeparator}mocks${pathSeparator}common${pathSeparator}party`;
 
 const messages = {
+	simpleGuestInfo: '{host} invites {guest} to a party.',
 	guestInfo: `{gender, select,
 		female {
 			{guestCount, plural, offset:1

--- a/tests/support/mocks/common/party.ts
+++ b/tests/support/mocks/common/party.ts
@@ -13,19 +13,19 @@ const messages = {
 	guestInfo: `{gender, select,
 		female {
 			{guestCount, plural, offset:1
-			=0 {{host} does not give a party.}
+			=0 {{host} does not host a party.}
 			=1 {{host} invites {guest} to her party.}
 			=2 {{host} invites {guest} and one other person to her party.}
 			other {{host} invites {guest} and # other people to her party.}}}
 		male {
 			{guestCount, plural, offset:1
-			=0 {{host} does not give a party.}
+			=0 {{host} does not host a party.}
 			=1 {{host} invites {guest} to his party.}
 			=2 {{host} invites {guest} and one other person to his party.}
 			other {{host} invites {guest} and # other people to his party.}}}
 		other {
 			{guestCount, plural, offset:1
-			=0 {{host} does not give a party.}
+			=0 {{host} does not host a party.}
 			=1 {{host} invites {guest} to their party.}
 			=2 {{host} invites {guest} and one other person to their party.}
 			other {{host} invites {guest} and # other people to their party.}}}}`

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -102,7 +102,7 @@ registerSuite({
 						host: 'Nita',
 						guestCount: 0
 					});
-					assert.strictEqual(formatted, 'Nita does not give a party.');
+					assert.strictEqual(formatted, 'Nita does not host a party.');
 
 					formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
 						host: 'Nita',
@@ -231,7 +231,7 @@ registerSuite({
 						host: 'Nita',
 						guestCount: 0
 					});
-					assert.strictEqual(formatted, 'Nita does not give a party.');
+					assert.strictEqual(formatted, 'Nita does not host a party.');
 
 					formatted = formatter({
 						host: 'Nita',

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -56,50 +56,91 @@ registerSuite({
 	},
 
 	formatMessage: {
-		'assert without a locale'() {
-			return i18n(partyBundle).then(() => {
-				let formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
-					host: 'Nita',
-					guestCount: 0
-				});
-				assert.strictEqual(formatted, 'Nita does not give a party.');
+		'without CLDR data': {
+			setup() {
+				cldrLoad.reset();
+			},
 
-				formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
-					host: 'Nita',
-					gender: 'female',
-					guestCount: 1,
-					guest: 'Bryan'
-				});
-				assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
+			teardown() {
+				return fetchCldrData([ 'en', 'fr' ]);
+			},
 
-				formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
-					host: 'Nita',
-					gender: 'female',
-					guestCount: 2,
-					guest: 'Bryan'
-				});
-				assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
+			'assert without loaded messages'() {
+				assert.throws(() => {
+					formatMessage('path/to/make-believe', 'messageKey');
+				}, Error, 'The bundle "path/to/make-believe" has not been registered.');
+			},
 
-				formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
-					host: 'Nita',
-					gender: 'female',
-					guestCount: 42,
-					guest: 'Bryan'
+			'assert tokens replaced'() {
+				return i18n(partyBundle).then(() => {
+					const formatted = formatMessage(partyBundle.bundlePath, 'simpleGuestInfo', {
+						host: 'Nita',
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
+
+					assert.throws(() => {
+						formatMessage(partyBundle.bundlePath, 'simpleGuestInfo', {
+							host: 'Nita'
+						});
+					}, Error, 'Missing property guest');
 				});
-				assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
-			});
+			},
+
+			'assert message without tokens'() {
+				return i18n(bundle).then(() => {
+					const formatted = formatMessage(bundle.bundlePath, 'hello');
+					assert.strictEqual(formatted, 'Hello');
+				});
+			}
 		},
 
-		'assert supported locale'() {
-			return i18n(bundle, 'ar').then(() => {
-				assert.strictEqual(formatMessage(bundle.bundlePath, 'hello', null, 'ar'), 'السلام عليكم');
-			});
-		},
+		'with CLDR data': {
+			'assert without a locale'() {
+				return i18n(partyBundle).then(() => {
+					let formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
+						host: 'Nita',
+						guestCount: 0
+					});
+					assert.strictEqual(formatted, 'Nita does not give a party.');
 
-		'assert unsupported locale'() {
-			return i18n(bundle, 'fr').then(() => {
-				assert.strictEqual(formatMessage(bundle.bundlePath, 'hello', null, 'fr'), 'Hello');
-			});
+					formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
+						host: 'Nita',
+						gender: 'female',
+						guestCount: 1,
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
+
+					formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
+						host: 'Nita',
+						gender: 'female',
+						guestCount: 2,
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
+
+					formatted = formatMessage(partyBundle.bundlePath, 'guestInfo', {
+						host: 'Nita',
+						gender: 'female',
+						guestCount: 42,
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
+				});
+			},
+
+			'assert supported locale'() {
+				return i18n(bundle, 'ar').then(() => {
+					assert.strictEqual(formatMessage(bundle.bundlePath, 'hello', {}, 'ar'), 'السلام عليكم');
+				});
+			},
+
+			'assert unsupported locale'() {
+				return i18n(bundle, 'fr').then(() => {
+					assert.strictEqual(formatMessage(bundle.bundlePath, 'hello', {}, 'fr'), 'Hello');
+				});
+			}
 		}
 	},
 
@@ -142,53 +183,95 @@ registerSuite({
 	},
 
 	getMessageFormatter: {
-		'assert without a locale'() {
-			return i18n(partyBundle).then(() => {
-				const formatter = getMessageFormatter(partyBundle.bundlePath, 'guestInfo');
-				let formatted = formatter({
-					host: 'Nita',
-					guestCount: 0
-				});
-				assert.strictEqual(formatted, 'Nita does not give a party.');
+		'without CLDR data': {
+			setup() {
+				cldrLoad.reset();
+			},
 
-				formatted = formatter({
-					host: 'Nita',
-					gender: 'female',
-					guestCount: 1,
-					guest: 'Bryan'
-				});
-				assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
+			teardown() {
+				return fetchCldrData([ 'en', 'fr' ]);
+			},
 
-				formatted = formatter({
-					host: 'Nita',
-					gender: 'female',
-					guestCount: 2,
-					guest: 'Bryan'
-				});
-				assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
+			'assert without loaded messages'() {
+				assert.throws(() => {
+					getMessageFormatter('path/to/make-believe', 'messageKey')();
+				}, Error, 'The bundle "path/to/make-believe" has not been registered.');
+			},
 
-				formatted = formatter({
-					host: 'Nita',
-					gender: 'female',
-					guestCount: 42,
-					guest: 'Bryan'
+			'assert tokens replaced'() {
+				return i18n(partyBundle).then(() => {
+					const formatter = getMessageFormatter(partyBundle.bundlePath, 'simpleGuestInfo');
+					const formatted = formatter({
+						host: 'Nita',
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
+
+					assert.throws(() => {
+						formatter({
+							host: 'Nita'
+						});
+					}, Error, 'Missing property guest');
 				});
-				assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
-			});
+			},
+
+			'assert message without tokens'() {
+				return i18n(bundle).then(() => {
+					const formatter = getMessageFormatter(bundle.bundlePath, 'hello');
+					assert.strictEqual(formatter(), 'Hello');
+				});
+			}
 		},
 
-		'assert supported locale'() {
-			return i18n(bundle, 'ar').then(() => {
-				const formatter = getMessageFormatter(bundle.bundlePath, 'hello', 'ar');
-				assert.strictEqual(formatter(), 'السلام عليكم');
-			});
-		},
+		'with CLDR data': {
+			'assert without a locale'() {
+				return i18n(partyBundle).then(() => {
+					const formatter = getMessageFormatter(partyBundle.bundlePath, 'guestInfo');
+					let formatted = formatter({
+						host: 'Nita',
+						guestCount: 0
+					});
+					assert.strictEqual(formatted, 'Nita does not give a party.');
 
-		'assert unsupported locale'() {
-			return i18n(bundle, 'fr').then(() => {
-				const formatter = getMessageFormatter(bundle.bundlePath, 'hello', 'fr');
-				assert.strictEqual(formatter(), 'Hello');
-			});
+					formatted = formatter({
+						host: 'Nita',
+						gender: 'female',
+						guestCount: 1,
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan to her party.');
+
+					formatted = formatter({
+						host: 'Nita',
+						gender: 'female',
+						guestCount: 2,
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan and one other person to her party.');
+
+					formatted = formatter({
+						host: 'Nita',
+						gender: 'female',
+						guestCount: 42,
+						guest: 'Bryan'
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan and 41 other people to her party.');
+				});
+			},
+
+			'assert supported locale'() {
+				return i18n(bundle, 'ar').then(() => {
+					const formatter = getMessageFormatter(bundle.bundlePath, 'hello', 'ar');
+					assert.strictEqual(formatter(), 'السلام عليكم');
+				});
+			},
+
+			'assert unsupported locale'() {
+				return i18n(bundle, 'fr').then(() => {
+					const formatter = getMessageFormatter(bundle.bundlePath, 'hello', 'fr');
+					assert.strictEqual(formatter(), 'Hello');
+				});
+			}
 		}
 	},
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updates the "format message" functionality to default to simple token  replacement when the CLDR data required for the ICU message format are not loaded.

Resolves #85 
