### PR TITLE
Allow nested objects to be used with message formatters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,18 @@ i18n(bundle, 'en').then(() => {
 });
 ```
 
+Alternatively, if the ICU message format is not being used, then dot notation can be used to extract values from objects:
+
+```typescript
+// Assume `guestInfo` is `{host.name} invites {guest.name} to the party.`
+const formatter = getMessageFormatter(bundle.bundlePath, 'guestInfo', 'en');
+let message = formatter({
+	host: { name: 'Margaret Mead' },
+	guest: { name: 'Laura Nader' }
+});
+console.log(message); // "Margaret Mead invites Laura Nader to the party."
+```
+
 #### ICU Message Formatting
 
 **Note**: This feature requires CLDR data (see above).
@@ -269,6 +281,7 @@ i18n(bundle, 'en').then(() => {
 As an example, suppose there is a locale bundle with a `guestInfo` message:
 
 ```typescript
+// Note that the ICU message format does not support dot notation.
 const messages = {
 	guestInfo: `{gender, select,
 		female {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -70,7 +70,7 @@ export interface Messages {
 }
 
 const PATH_SEPARATOR: string = has('host-node') ? require('path').sep : '/';
-const TOKEN_PATTERN = /\{([a-z0-9_]+)\}/gi;
+const TOKEN_PATTERN = /\{([a-z0-9_\.]+)\}/gi;
 const VALID_PATH_PATTERN = new RegExp(`\\${PATH_SEPARATOR}[^\\${PATH_SEPARATOR}]+\$`);
 const bundleMap = new Map<string, Map<string, Messages>>();
 const formatterMap = new Map<string, MessageFormatter>();
@@ -354,7 +354,9 @@ export function getMessageFormatter(bundlePath: string, key: string, locale?: st
 
 	return function (options: FormatOptions = Object.create(null)) {
 		return messages[key].replace(TOKEN_PATTERN, (token: string, property: string) => {
-			const value = options[property];
+			const value = property.split('.').reduce((value: any, key: string) => {
+				return value && value[key];
+			}, options);
 
 			if (typeof value === 'undefined') {
 				throw new Error(`Missing property ${property}`);

--- a/tests/support/mocks/common/party.ts
+++ b/tests/support/mocks/common/party.ts
@@ -10,6 +10,7 @@ const bundlePath = `${basePath}tests${pathSeparator}support${pathSeparator}mocks
 
 const messages = {
 	simpleGuestInfo: '{host} invites {guest} to a party.',
+	simpleGuestInfoDotNotation: '{host.name} invites {guest.name} to a party.',
 	guestInfo: `{gender, select,
 		female {
 			{guestCount, plural, offset:1

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -87,6 +87,23 @@ registerSuite({
 				});
 			},
 
+			'assert dot notation tokens replaced'() {
+				return i18n(partyBundle).then(() => {
+					const formatted = formatMessage(partyBundle.bundlePath, 'simpleGuestInfoDotNotation', {
+						host: { name: 'Nita' },
+						guest: { name: 'Bryan' }
+					});
+					assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
+
+					assert.throws(() => {
+						formatMessage(partyBundle.bundlePath, 'simpleGuestInfoDotNotation', {
+							host: { name: 'Nita' },
+							guest: {}
+						});
+					}, Error, 'Missing property guest.name');
+				});
+			},
+
 			'assert message without tokens'() {
 				return i18n(bundle).then(() => {
 					const formatted = formatMessage(bundle.bundlePath, 'hello');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds support for dot notation within message bundles _when the ICU format is not needed_ (i.e., when the relevant CLDR data have not been loaded). Since the ICU message format does not support dot notation, an additional helper method (`flattenFormatOptions`) is included to allow object keys to be separated by underscores rather than periods.

Resolves #87 
