### PR TITLE
Default to system locale for message formatters.

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -353,7 +353,7 @@ export function getMessageFormatter(bundlePath: string, key: string, locale?: st
 	}
 
 	return function (options: FormatOptions = Object.create(null)) {
-		return (<Messages> messages)[key].replace(TOKEN_PATTERN, (token: string, property: string) => {
+		return messages[key].replace(TOKEN_PATTERN, (token: string, property: string) => {
 			const value = options[property];
 
 			if (typeof value === 'undefined') {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -346,14 +346,14 @@ export function getMessageFormatter(bundlePath: string, key: string, locale?: st
 	}
 
 	const cached = bundleMap.get(bundlePath);
-	const messages = cached && cached.get(locale || 'root');
+	const messages = cached ? (cached.get(locale || getRootLocale()) || cached.get('root')) : null;
 
 	if (!messages) {
 		throw new Error(`The bundle "${bundlePath}" has not been registered.`);
 	}
 
 	return function (options: FormatOptions = Object.create(null)) {
-		return messages[key].replace(TOKEN_PATTERN, (token: string, property: string) => {
+		return (<Messages> messages)[key].replace(TOKEN_PATTERN, (token: string, property: string) => {
 			const value = options[property];
 
 			if (typeof value === 'undefined') {

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -92,6 +92,14 @@ registerSuite({
 					const formatted = formatMessage(bundle.bundlePath, 'hello');
 					assert.strictEqual(formatted, 'Hello');
 				});
+			},
+
+			'assert default locale used'() {
+				switchLocale('ar');
+				return i18n(bundle, 'ar').then(() => {
+					const formatted = formatMessage(bundle.bundlePath, 'hello');
+					assert.strictEqual(formatted, 'السلام عليكم');
+				});
 			}
 		},
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Allows the root locale to be assumed when using `formatMessage` or `getMessageFormatter`.