### PR TITLE
Pin Globalize version and fix unit tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@dojo/shim": "next"
   },
   "dependencies": {
-    "globalize": "^1.2.3"
+    "globalize": "1.3.0"
   },
   "devDependencies": {
     "@dojo/interfaces": "next",

--- a/tests/unit/date.ts
+++ b/tests/unit/date.ts
@@ -32,10 +32,11 @@ function getTimezoneDate(date: Date, offset: number = 0): Date {
 
 function getTimezones(date: Date, standard: string = 'GMT') {
 	const [ sign, longOffset, fullOffset ] = getOffsets(date);
-	const fullSeparator = (sign < 0) ? '+' : String.fromCharCode(standard === 'UTC' ? 8722 : 45);
+	const timeSeparator = standard === 'UTC' ? '\u2212' : '-';
+	const fullSeparator = (sign < 0) ? '+' : timeSeparator;
 	const zeroPattern = /^[0:]+$/;
 	return [
-		`${standard}${longOffset ? ((sign < 0) ? '+' : '-') + longOffset : ''}`,
+		`${standard}${longOffset ? ((sign < 0) ? '+' : timeSeparator) + longOffset : ''}`,
 		`${standard}${zeroPattern.test(fullOffset as string) ? '' : fullSeparator + fullOffset}`
 	];
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Pins the Globalize version to 1.3.0 and fixes the timezone offset separator used in the unit tests.

Resolves #96 
