### PR TITLE
Use @dojo/core/load.useDefault, @dojo/shim/global

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,10 +1,10 @@
 /* tslint:disable:interface-name */
 import Evented from '@dojo/core/Evented';
 import has from '@dojo/core/has';
-import global from '@dojo/core/global';
 import { assign } from '@dojo/core/lang';
-import load from '@dojo/core/load';
+import load, { useDefault } from '@dojo/core/load';
 import { Handle } from '@dojo/interfaces/core';
+import global from '@dojo/shim/global';
 import Map from '@dojo/shim/Map';
 import Observable, { Observer, Subscription, SubscriptionObserver } from '@dojo/shim/Observable';
 import Promise from '@dojo/shim/Promise';
@@ -130,9 +130,7 @@ function getIcuMessageFormatter(bundlePath: string, key: string, locale?: string
  */
 const loadLocaleBundles = (function () {
 	function mapMessages<T extends Messages>(modules: LocaleModule<T>[]): T[] {
-		return modules.map((localeModule: LocaleModule<T>): T => {
-			return localeModule.default as T;
-		});
+		return modules.map((localeModule: LocaleModule<T>): T => useDefault(localeModule));
 	}
 
 	return function<T extends Messages>(paths: string[]): Promise<T[]> {

--- a/tests/support/mocks/common/es/main.ts
+++ b/tests/support/mocks/common/es/main.ts
@@ -1,0 +1,5 @@
+export = {
+	hello: 'Hola',
+	helloReply: 'Hola',
+	goodbye: 'Adiós'
+};

--- a/tests/support/mocks/common/main.ts
+++ b/tests/support/mocks/common/main.ts
@@ -2,7 +2,8 @@ import has from '@dojo/core/has';
 
 const locales = [
 	'ar',
-	'ar-JO'
+	'ar-JO',
+	'es'
 ];
 
 // TODO: The default loader attempts to use the native Node.js `require` when running on Node. However, the Intern

--- a/tests/unit/cldr/load/webpack.ts
+++ b/tests/unit/cldr/load/webpack.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import global from '@dojo/core/global';
+import global from '@dojo/shim/global';
 import loadCldrData, {
 	CldrData,
 	isLoaded,

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -1,6 +1,6 @@
-import global from '@dojo/core/global';
 import has from '@dojo/core/has';
 import { assign } from '@dojo/core/lang';
+import global from '@dojo/shim/global';
 import * as Globalize from 'globalize';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
@@ -361,6 +361,16 @@ registerSuite({
 					helloReply: 'Hello',
 					goodbye: 'Goodbye'
 				}, 'Default messages returned when bundle provides no locales.');
+			});
+		},
+
+		'assert no default export'() {
+			return i18n(bundle, 'es').then(function (messages: Messages) {
+				assert.deepEqual(messages, {
+					hello: 'Hola',
+					helloReply: 'Hola',
+					goodbye: 'Adiós'
+				}, 'The entire exported module should be used when no default is provided.');
 			});
 		},
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updates locale-specific message loading to rely on `@dojo/core/load.useDefault` to resolve the default export, and replaces the deprecated `@dojo/core/global` with `@dojo/shim/global`.

Resolves #98 
