### PR TITLE
Update CI for new release of grunt-dojo2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
   global:
   - SAUCE_USERNAME: dojo2-ts-ci
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
-  - BROWSERSTACK_USERNAME: dtktestaccount1
-  - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
+  - BROWSERSTACK_USERNAME: dylanschiemann2
+  - BROWSERSTACK_ACCESS_KEY: 2upt88qsxsqqeukQvecu
 before_install:
 - if [ ${TRAVIS_BRANCH-""} == "master" ] && [ -n ${encrypted_12c8071d2874_key-""}
   ]; then openssl aes-256-cbc -K $encrypted_12c8071d2874_key -iv $encrypted_12c8071d2874_iv

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:saucelabs
+- grunt intern:saucelabs --test-reporter
 - grunt uploadCoverage
 - grunt doc
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:saucelabs --test-reporter
+- grunt intern:browserstack --test-reporter
 - grunt uploadCoverage
 - grunt doc
 notifications:

--- a/intern.json
+++ b/intern.json
@@ -18,8 +18,7 @@
 				{ "name": "cldrjs", "location": "node_modules/cldrjs" },
 				{ "name": "@dojo", "location": "node_modules/@dojo" },
 				{ "name": "globalize", "location": "node_modules/globalize", "main": "dist/globalize" },
-				{ "name": "sinon", "location": "node_modules/sinon/pkg", "main": "sinon" },
-				{ "name": "grunt-dojo2", "location": "node_modules/grunt-dojo2" }
+				{ "name": "sinon", "location": "node_modules/sinon/pkg", "main": "sinon" }
 			],
 			"map": {
 				"globalize": {
@@ -31,25 +30,22 @@
 			}
 		}
 	},
+	"coverage": [
+		"./_build/src/**/*.js"
+	],
 	"configs": {
-		"coverage": {
-			"coverage": [
-				"./_build/src/**/*.js"
-			]
-		},
 		"remoteCapabilities": {
 			"project": "Dojo 2",
 			"name": "@dojo/i18n"
 		},
 		"local": {
-			"extends": [ "coverage" ],
 			"tunnel": "selenium",
 			"environments+": [
 				{ "browserName": "chrome" }
 			]
 		},
 		"browserstack": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "browserstack",
 			"capabilities+": {
@@ -66,7 +62,7 @@
 			]
 		},
 		"saucelabs": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "saucelabs",
 			"capabilities+": {

--- a/intern.json
+++ b/intern.json
@@ -1,4 +1,9 @@
 {
+	"capabilities": {
+		"project": "Dojo 2",
+		"name": "@dojo/i18n",
+		"browserstack.debug": false
+	},
 	"environments": [
 		{ "browserName": "node" }
 	],
@@ -34,10 +39,6 @@
 		"./_build/src/**/*.js"
 	],
 	"configs": {
-		"remoteCapabilities": {
-			"project": "Dojo 2",
-			"name": "@dojo/i18n"
-		},
 		"local": {
 			"tunnel": "selenium",
 			"environments+": [
@@ -45,30 +46,17 @@
 			]
 		},
 		"browserstack": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "browserstack",
-			"capabilities+": {
-				"browserstack.debug": false
-			},
 			"environments+": [
 				{ "browserName": "internet explorer", "version": "11" },
 				{ "browserName": "edge" },
 				{ "browserName": "firefox", "platform": "WINDOWS" },
 				{ "browserName": "chrome", "platform": "WINDOWS" },
 				{ "browserName": "safari", "version": "9.1", "platform": "MAC" }
-				// BrowserStack uses iOS 9.1 and some of the tests fail.  I looks like a missing locale problem
-				// { "browserName": "iPhone" }
 			]
 		},
 		"saucelabs": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "saucelabs",
-			"capabilities+": {
-				"fixSessionCapabilities": false
-			},
-
 			"defaultTimeout": 10000,
 			"environments+": [
 				{ "browserName": "internet explorer", "version": [ "10.0", "11.0" ], "platform": "Windows 7" },


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`grunt-dojo2` has been updated in [a PR](https://github.com/dojo/grunt-dojo2/pull/162) to use Intern 4 exclusively which includes a reporter similar to the one developed for Intern 3. This PR updates the CI scripts to use these features and return the grunt tasks back to feature parity with the tasks before the Intern 4 conversion. The `grunt-dojo2` PR **MUST LAND** and be released before this can land.