### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -397,8 +397,17 @@ formatUnit(1000, 'meter', null, 'fr); // 1 000 mètres'
 
 ## How do I contribute?
 
-We appreciate your interest!  Please see the [Guidelines Repository](https://github.com/dojo/guidelines#readme) for the
-Contributing Guidelines and Style Guide.
+We appreciate your interest!  Please see the [Guidelines Repository](https://github.com/dojo/guidelines#readme) for the Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/i18n",
-  "version": "0.4.0",
+  "version": "0.4.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,9 +17,9 @@
       "dev": true
     },
     "@dojo/interfaces": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
-      "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
       "dev": true,
       "requires": {
         "@types/yargs": "8.0.3"
@@ -50,7 +50,7 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
@@ -73,7 +73,7 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
@@ -81,9 +81,9 @@
       }
     },
     "@types/babel-types": {
-      "version": "6.25.2",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
-      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
+      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
       "dev": true
     },
     "@types/benchmark": {
@@ -99,13 +99,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/chai": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.9.tgz",
-      "integrity": "sha512-Vr1llSMwdJRIISR7kfeSZokL24942QLXcjjPv9xzIGWSXBu+cLeALSAqIe2sRKW1M+9R5c6v9E4BOGk6ewBOXQ==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/charm": {
@@ -114,13 +114,19 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/diff": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -130,17 +136,17 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.0",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.57",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
-      "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz",
+      "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/fs-extra": {
@@ -149,17 +155,18 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.58"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.2",
+        "@types/node": "8.5.2"
       }
     },
     "@types/grunt": {
@@ -168,7 +175,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/handlebars": {
@@ -207,7 +214,7 @@
       "integrity": "sha512-BWj7zRtwVU5KzuYL/zNuVoSvYWIpT02smNMpQwQbJjwEyITEGSKsxVIT4b2bzXCWFMq76ss0sdY/5yw3NwTlIA==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.2",
+        "@types/babel-types": "7.0.0",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/source-map": "0.1.29"
       }
@@ -248,9 +255,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.88",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.88.tgz",
-      "integrity": "sha512-S+7dONqCP8kXqOPCPxra7Vw8FndWS8pNfVkClMSzRCPMjXkA3BaI3ybMBCiSd4y+r1vC49UEjNthnm+fO8J/dw==",
+      "version": "4.14.91",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
+      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
     "@types/marked": {
@@ -272,15 +279,15 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.58",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.58.tgz",
-      "integrity": "sha512-V746iUU7eHNdzQipoACuguDlVhC7IHK8CES1jSkuFt352wwA84BCWPXaGekBd7R5XdNK5ReHONDVKxlL9IreAw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
+      "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
       "dev": true
     },
     "@types/platform": {
@@ -295,7 +302,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/serve-static": {
@@ -304,7 +311,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.0",
         "@types/mime": "2.0.0"
       }
     },
@@ -320,7 +327,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/sinon": {
@@ -347,7 +354,7 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.58"
+        "@types/node": "8.5.2"
       }
     },
     "@types/yargs": {
@@ -428,6 +435,21 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -438,6 +460,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
       "dev": true
     },
     "any-promise": {
@@ -455,6 +489,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -589,7 +629,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000782",
+        "caniuse-db": "1.0.30000784",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -650,14 +690,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.2",
+        "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.2.tgz",
-          "integrity": "sha1-vEZIZW59ydyA19PHu8Fy2W50TmM=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -918,8 +958,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000782",
-        "electron-to-chromium": "1.3.28"
+        "caniuse-db": "1.0.30000784",
+        "electron-to-chromium": "1.3.30"
       }
     },
     "buffer": {
@@ -974,15 +1014,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000782",
+        "caniuse-db": "1.0.30000784",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000782",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000782.tgz",
-      "integrity": "sha1-2IFbzhV4w1Cs7REyUHMBIF4Pq1M=",
+      "version": "1.0.30000784",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000784.tgz",
+      "integrity": "sha1-G+lQEtlInHcZB0+BruV9vf/mNhs=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1067,6 +1107,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1112,6 +1158,53 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "2.1.0",
@@ -1420,6 +1513,12 @@
         "color-name": "1.1.3"
       }
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
@@ -1557,6 +1656,45 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1820,6 +1958,12 @@
         }
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1923,6 +2067,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -2100,10 +2250,25 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
+    "electron-releases": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
+      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
+      "dev": true
+    },
     "electron-to-chromium": {
-      "version": "1.3.28",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
-      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+      "version": "1.3.30",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
+      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
+      "dev": true,
+      "requires": {
+        "electron-releases": "2.1.0"
+      }
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "emojis-list": {
@@ -2190,6 +2355,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -2238,6 +2413,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -2354,14 +2535,21 @@
       "dev": true
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2391,6 +2579,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2461,6 +2659,12 @@
           "dev": true
         }
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2621,6 +2825,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -3001,6 +3211,12 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -3013,6 +3229,29 @@
             "minimatch": "3.0.4",
             "once": "1.3.3",
             "path-is-absolute": "1.0.1"
+          }
+        },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
           }
         }
       }
@@ -3160,9 +3399,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -3185,7 +3424,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3287,7 +3526,7 @@
       "requires": {
         "chalk": "1.1.3",
         "commander": "2.12.2",
-        "is-my-json-valid": "2.16.1",
+        "is-my-json-valid": "2.17.1",
         "pinkie-promise": "2.0.1"
       }
     },
@@ -3424,6 +3663,31 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3505,12 +3769,12 @@
       "requires": {
         "@dojo/core": "0.3.0",
         "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "0.2.3",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.9",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3521,7 +3785,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.88",
+        "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3745,6 +4009,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3804,9 +4083,9 @@
       }
     },
     "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -3842,6 +4121,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3869,6 +4157,12 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -3879,6 +4173,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -4169,6 +4469,67 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -4318,6 +4679,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4337,11 +4704,235 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -4527,6 +5118,62 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
     "lolex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -4598,9 +5245,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==",
       "dev": true
     },
     "make-error-cause": {
@@ -4609,7 +5256,7 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "1.3.0"
+        "make-error": "1.3.2"
       }
     },
     "map-obj": {
@@ -4619,9 +5266,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -4855,6 +5502,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4862,6 +5518,17 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.2.14"
       }
     },
     "npmconf": {
@@ -4956,6 +5623,12 @@
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ=",
       "dev": true
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -4986,6 +5659,18 @@
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
+      }
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "os-homedir": {
@@ -5079,6 +5764,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -5705,7 +6396,7 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14",
+        "postcss": "6.0.15",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
@@ -5727,6 +6418,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5736,14 +6438,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5753,9 +6455,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5904,7 +6606,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5925,6 +6627,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5934,14 +6647,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5951,9 +6664,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5968,7 +6681,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5989,6 +6702,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5998,14 +6722,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6015,9 +6739,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6032,7 +6756,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6053,6 +6777,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -6062,14 +6797,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6079,9 +6814,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6096,7 +6831,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6117,6 +6852,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -6126,14 +6872,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -6143,9 +6889,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6368,6 +7114,39 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -6860,6 +7639,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6877,6 +7662,16 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
@@ -6914,6 +7709,23 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -7146,6 +7958,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -7242,6 +8060,12 @@
         }
       }
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -7255,6 +8079,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -7307,6 +8140,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -7403,6 +8247,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tape": {
       "version": "2.3.0",
@@ -7613,9 +8463,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7624,9 +8474,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7648,7 +8499,32 @@
             "once": "1.3.3",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -8860,7 +9736,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.88",
+        "@types/lodash": "4.14.91",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -8868,7 +9744,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.7",
+        "marked": "0.3.9",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "scripts": {
     "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "peerDependencies": {
@@ -37,8 +39,28 @@
     "cldr-data": "~32.0.0",
     "grunt": "^1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
+    "prettier": "1.9.2",
     "sinon": "^1.17.6",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -131,8 +131,7 @@ function registerLocaleData(cache: any, localeData: any) {
 
 			if (typeof value === 'boolean') {
 				cache[key] = true;
-			}
-			else {
+			} else {
 				registerLocaleData(value, localeData[key]);
 			}
 		}

--- a/src/date.ts
+++ b/src/date.ts
@@ -94,9 +94,19 @@ export function formatDate(value: Date, optionsOrLocale?: DateFormatterOptions |
  * @param locale
  * An optional locale. Defaults to the current locale.
  */
-export function formatRelativeTime(value: number, unit: string, options?: RelativeTimeFormatterOptions, locale?: string): string;
+export function formatRelativeTime(
+	value: number,
+	unit: string,
+	options?: RelativeTimeFormatterOptions,
+	locale?: string
+): string;
 export function formatRelativeTime(value: number, unit: string, locale?: string): string;
-export function formatRelativeTime(value: number, unit: string, optionsOrLocale?: RelativeTimeFormatterOptions | string, locale?: string): string {
+export function formatRelativeTime(
+	value: number,
+	unit: string,
+	optionsOrLocale?: RelativeTimeFormatterOptions | string,
+	locale?: string
+): string {
 	return globalizeDelegator<number, RelativeTimeFormatterOptions, string>('formatRelativeTime', {
 		locale,
 		optionsOrLocale,
@@ -165,9 +175,17 @@ export function getDateParser(optionsOrLocale?: DateFormatterOptions | string, l
  * A function that accepts a relative time number and returns a formatted string. Positive numbers indicate future
  * events (e.g., "in 2 days") while negative numbers represent past events (e.g., "1 day ago").
  */
-export function getRelativeTimeFormatter(unit: string, options?: RelativeTimeFormatterOptions, locale?: string): NumberFormatter;
+export function getRelativeTimeFormatter(
+	unit: string,
+	options?: RelativeTimeFormatterOptions,
+	locale?: string
+): NumberFormatter;
 export function getRelativeTimeFormatter(unit: string, locale?: string): NumberFormatter;
-export function getRelativeTimeFormatter(unit: string, optionsOrLocale?: RelativeTimeFormatterOptions | string, locale?: string): NumberFormatter {
+export function getRelativeTimeFormatter(
+	unit: string,
+	optionsOrLocale?: RelativeTimeFormatterOptions | string,
+	locale?: string
+): NumberFormatter {
 	return globalizeDelegator<string, RelativeTimeFormatterOptions, NumberFormatter>('relativeTimeFormatter', {
 		locale,
 		optionsOrLocale,

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,16 +45,8 @@ import {
 	PluralTypeOption,
 	RoundNumberOption
 } from './number';
-import {
-	formatUnit,
-	getUnitFormatter,
-	UnitFormatterOptions,
-	UnitLength
-} from './unit';
-import {
-	generateLocales,
-	normalizeLocale
-} from './util/main';
+import { formatUnit, getUnitFormatter, UnitFormatterOptions, UnitLength } from './unit';
+import { generateLocales, normalizeLocale } from './util/main';
 import loadCldrData from './cldr/load';
 
 export default i18n;

--- a/src/number.ts
+++ b/src/number.ts
@@ -8,7 +8,7 @@ export type CurrencyStyleOption = 'accounting' | 'code' | 'name' | 'symbol';
 export type NumberStyleOption = 'decimal' | 'percent';
 export type PluralGroup = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other';
 export type PluralTypeOption = 'cardinal' | 'ordinal';
-export type RoundNumberOption =  'ceil' | 'floor' | 'round' | 'truncate';
+export type RoundNumberOption = 'ceil' | 'floor' | 'round' | 'truncate';
 
 export interface CommonNumberFormatterOptions {
 	/**
@@ -122,9 +122,19 @@ export type PluralGeneratorOptions = {
  * @return
  * The formatted currency string.
  */
-export function formatCurrency(value: number, currency: string, options?: CurrencyFormatterOptions, locale?: string): string;
+export function formatCurrency(
+	value: number,
+	currency: string,
+	options?: CurrencyFormatterOptions,
+	locale?: string
+): string;
 export function formatCurrency(value: number, currency: string, locale?: string): string;
-export function formatCurrency(value: number, currency: string, optionsOrLocale?: CurrencyFormatterOptions | string, locale?: string): string {
+export function formatCurrency(
+	value: number,
+	currency: string,
+	optionsOrLocale?: CurrencyFormatterOptions | string,
+	locale?: string
+): string {
 	return globalizeDelegator<number, CurrencyFormatterOptions, string>('formatCurrency', {
 		locale,
 		optionsOrLocale,
@@ -150,7 +160,11 @@ export function formatCurrency(value: number, currency: string, optionsOrLocale?
  */
 export function formatNumber(value: number, options?: NumberFormatterOptions, locale?: string): string;
 export function formatNumber(value: number, locale?: string): string;
-export function formatNumber(value: number, optionsOrLocale?: NumberFormatterOptions | string, locale?: string): string {
+export function formatNumber(
+	value: number,
+	optionsOrLocale?: NumberFormatterOptions | string,
+	locale?: string
+): string {
 	return globalizeDelegator<number, NumberFormatterOptions, string>('formatNumber', {
 		locale,
 		optionsOrLocale,
@@ -174,9 +188,17 @@ export function formatNumber(value: number, optionsOrLocale?: NumberFormatterOpt
  * @return
  * A function that accepts a number and returns a formatted currency string.
  */
-export function getCurrencyFormatter(currency: string, options?: CurrencyFormatterOptions, locale?: string): NumberFormatter;
+export function getCurrencyFormatter(
+	currency: string,
+	options?: CurrencyFormatterOptions,
+	locale?: string
+): NumberFormatter;
 export function getCurrencyFormatter(currency: string, locale?: string): NumberFormatter;
-export function getCurrencyFormatter(currency: string, optionsOrLocale?: CurrencyFormatterOptions | string, locale?: string): NumberFormatter {
+export function getCurrencyFormatter(
+	currency: string,
+	optionsOrLocale?: CurrencyFormatterOptions | string,
+	locale?: string
+): NumberFormatter {
 	return globalizeDelegator<string, CurrencyFormatterOptions, NumberFormatter>('currencyFormatter', {
 		locale,
 		optionsOrLocale,
@@ -198,7 +220,10 @@ export function getCurrencyFormatter(currency: string, optionsOrLocale?: Currenc
  */
 export function getNumberFormatter(options?: NumberFormatterOptions, locale?: string): NumberFormatter;
 export function getNumberFormatter(locale?: string): NumberFormatter;
-export function getNumberFormatter(optionsOrLocale?: NumberFormatterOptions | string, locale?: string): NumberFormatter {
+export function getNumberFormatter(
+	optionsOrLocale?: NumberFormatterOptions | string,
+	locale?: string
+): NumberFormatter {
 	return globalizeDelegator<NumberFormatterOptions, NumberFormatter>('numberFormatter', {
 		locale,
 		optionsOrLocale
@@ -241,7 +266,10 @@ export function getNumberParser(optionsOrLocale?: NumberFormatterOptions | strin
  */
 export function getPluralGenerator(options?: PluralGeneratorOptions, locale?: string): NumberFormatter;
 export function getPluralGenerator(locale?: string): NumberFormatter;
-export function getPluralGenerator(optionsOrLocale?: PluralGeneratorOptions | string, locale?: string): NumberFormatter {
+export function getPluralGenerator(
+	optionsOrLocale?: PluralGeneratorOptions | string,
+	locale?: string
+): NumberFormatter {
 	return globalizeDelegator<PluralGeneratorOptions, NumberFormatter>('pluralGenerator', {
 		locale,
 		optionsOrLocale

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -37,7 +37,12 @@ export type UnitFormatterOptions = {
  */
 export function formatUnit(value: number, unit: string, options?: UnitFormatterOptions, locale?: string): string;
 export function formatUnit(value: number, unit: string, locale?: string): string;
-export function formatUnit(value: number, unit: string, optionsOrLocale?: UnitFormatterOptions | string, locale?: string): string {
+export function formatUnit(
+	value: number,
+	unit: string,
+	optionsOrLocale?: UnitFormatterOptions | string,
+	locale?: string
+): string {
 	return globalizeDelegator<number, UnitFormatterOptions, string>('formatUnit', {
 		locale,
 		optionsOrLocale,
@@ -63,7 +68,11 @@ export function formatUnit(value: number, unit: string, optionsOrLocale?: UnitFo
  */
 export function getUnitFormatter(unit: string, options?: UnitFormatterOptions, locale?: string): NumberFormatter;
 export function getUnitFormatter(unit: string, locale?: string): NumberFormatter;
-export function getUnitFormatter(unit: string, optionsOrLocale?: UnitFormatterOptions | string, locale?: string): NumberFormatter {
+export function getUnitFormatter(
+	unit: string,
+	optionsOrLocale?: UnitFormatterOptions | string,
+	locale?: string
+): NumberFormatter {
 	return globalizeDelegator<string, UnitFormatterOptions, NumberFormatter>('unitFormatter', {
 		locale,
 		optionsOrLocale,

--- a/src/util/globalize.ts
+++ b/src/util/globalize.ts
@@ -62,9 +62,12 @@ export default function getGlobalize(locale?: string) {
  */
 export function globalizeDelegator<O, R>(method: string, args: DelegatorOptions<O>): R;
 export function globalizeDelegator<T, O, R>(method: string, args: FormatterDelegatorOptions<T, O>): R;
-export function globalizeDelegator<T, O, R>(method: string, args: DelegatorOptions<O> | FormatterDelegatorOptions<T, O>): R {
+export function globalizeDelegator<T, O, R>(
+	method: string,
+	args: DelegatorOptions<O> | FormatterDelegatorOptions<T, O>
+): R {
 	const { locale, options, value, unit } = normalizeFormatterArguments<T, O>(args);
-	const methodArgs: any[] = typeof value !== 'undefined' ? [ value ] : [];
+	const methodArgs: any[] = typeof value !== 'undefined' ? [value] : [];
 
 	if (typeof unit !== 'undefined') {
 		methodArgs.push(unit);
@@ -75,5 +78,5 @@ export function globalizeDelegator<T, O, R>(method: string, args: DelegatorOptio
 	}
 
 	const globalize = getGlobalize(locale);
-	return (<any> globalize)[method].apply(globalize, methodArgs);
+	return (<any>globalize)[method].apply(globalize, methodArgs);
 }

--- a/src/util/main.ts
+++ b/src/util/main.ts
@@ -17,7 +17,7 @@ export function generateLocales(locale: string): string[] {
 	const normalized = normalizeLocale(locale);
 	const parts = normalized.split('-');
 	let current = parts[0];
-	const result: string[] = [ current ];
+	const result: string[] = [current];
 
 	for (let i = 0; i < parts.length - 1; i += 1) {
 		current += '-' + parts[i + 1];
@@ -35,7 +35,7 @@ export function generateLocales(locale: string): string[] {
  *
  * @return The normalized locale.
  */
-export const normalizeLocale = (function () {
+export const normalizeLocale = (function() {
 	function removeTrailingSeparator(value: string): string {
 		return value.replace(/(\-|_)$/, '');
 	}
@@ -45,12 +45,16 @@ export const normalizeLocale = (function () {
 			return removeTrailingSeparator(locale);
 		}
 
-		return locale.split('.').slice(0, -1).map((part: string): string => {
-			return removeTrailingSeparator(part).replace(/_/g, '-');
-		}).join('-');
+		return locale
+			.split('.')
+			.slice(0, -1)
+			.map((part: string): string => {
+				return removeTrailingSeparator(part).replace(/_/g, '-');
+			})
+			.join('-');
 	}
 
-	return function (locale: string): string {
+	return function(locale: string): string {
 		const normalized = normalize(locale);
 
 		if (!validateLocale(normalized)) {

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -13,36 +13,42 @@ export interface Thenable<T> {
 }
 
 export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean> {
-	return promise.then<any>(function () {
-		throw new Error('unexpected code path');
-	}, function () {
-		return true; // expect rejection
-	});
+	return promise.then<any>(
+		function() {
+			throw new Error('unexpected code path');
+		},
+		function() {
+			return true; // expect rejection
+		}
+	);
 }
 
 export function throwImmediatly() {
 	throw new Error('unexpected code path');
 }
 
-const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
+const getJson: (paths: string[]) => Promise<CldrData[]> = (function() {
 	if (has('host-node')) {
-		return function (paths: string[]): Promise<CldrData[]> {
-			return Promise.resolve(paths.map(path => require(path) as CldrData));
+		return function(paths: string[]): Promise<CldrData[]> {
+			return Promise.resolve(paths.map((path) => require(path) as CldrData));
 		};
 	}
 
-	return function (paths: string[]): Promise<CldrData[]> {
-		return Promise.all(paths.map((path: string): Promise<CldrData> => {
-			if (typeof require.toUrl === 'function') {
-				path = require.toUrl(path);
-			}
+	return function(paths: string[]): Promise<CldrData[]> {
+		return Promise.all(
+			paths.map((path: string): Promise<CldrData> => {
+				if (typeof require.toUrl === 'function') {
+					path = require.toUrl(path);
+				}
 
-			return <Promise<CldrData>> request.get(path)
-				.then(response => response.json())
-				.then((data: CldrData) => {
-					return data;
-				});
-		}));
+				return <Promise<CldrData>>request
+					.get(path)
+					.then((response) => response.json())
+					.then((data: CldrData) => {
+						return data;
+					});
+			})
+		);
 	};
 })();
 
@@ -50,17 +56,18 @@ const getJson: (paths: string[]) => Promise<CldrData[]> = (function () {
  * Load into Globalize.js all CLDR data for the specified locales.
  */
 export async function fetchCldrData(locales: string | string[]): Promise<void> {
-	locales = Array.isArray(locales) ? locales : [ locales ];
+	locales = Array.isArray(locales) ? locales : [locales];
 
 	await locales.map((locale: string) => {
 		if (isLoaded('main', locale)) {
 			return Promise.resolve();
 		}
 
-		const paths = [ 'ca-gregorian', 'currencies', 'dateFields', 'numbers', 'timeZoneNames', 'units' ]
-			.map((name: string) => `cldr-data/main/${locale}/${name}.json`);
+		const paths = ['ca-gregorian', 'currencies', 'dateFields', 'numbers', 'timeZoneNames', 'units'].map(
+			(name: string) => `cldr-data/main/${locale}/${name}.json`
+		);
 		return getJson(paths).then((result: CldrData[]) => {
-			return result.map(data => loadCldrData(data));
+			return result.map((data) => loadCldrData(data));
 		});
 	});
 
@@ -76,7 +83,7 @@ export async function fetchCldrData(locales: string | string[]): Promise<void> {
 		].map((name: string) => `cldr-data/supplemental/${name}.json`);
 
 		await getJson(supplementalPaths).then((result: CldrData[]) => {
-			return result.map(data => loadCldrData(data));
+			return result.map((data) => loadCldrData(data));
 		});
 	}
 }

--- a/tests/unit/cldr/load.ts
+++ b/tests/unit/cldr/load.ts
@@ -1,20 +1,13 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import baseLoad, {
-	isLoaded,
-	mainPackages,
-	reset,
-	supplementalPackages
-} from '../../../src/cldr/load';
+import baseLoad, { isLoaded, mainPackages, reset, supplementalPackages } from '../../../src/cldr/load';
 
 registerSuite('cldr/load', {
-
 	afterEach() {
 		reset();
 	},
 
 	tests: {
-
 		mainPackages() {
 			assert.isTrue(Object.isFrozen(mainPackages), 'Should be frozen.');
 			assert.sameMembers(mainPackages as any[], [
@@ -110,7 +103,6 @@ registerSuite('cldr/load', {
 			},
 
 			tests: {
-
 				'main only'() {
 					reset('main');
 
@@ -118,7 +110,10 @@ registerSuite('cldr/load', {
 					assert.isFalse(isLoaded('main', 'zh-MO'), '"main" data should be cleared.');
 					assert.isFalse(isLoaded('main', 'zh', 'numbers'), '"main" data should be cleared.');
 
-					assert.isTrue(isLoaded('supplemental', 'likelySubtags'), '"supplemental" data should not be cleared.');
+					assert.isTrue(
+						isLoaded('supplemental', 'likelySubtags'),
+						'"supplemental" data should not be cleared.'
+					);
 				},
 
 				'supplemental only'() {

--- a/tests/unit/date.ts
+++ b/tests/unit/date.ts
@@ -20,7 +20,7 @@ function getOffsets(date: Date) {
 	const fullSecondOffset = padStart(String(offset % 60), 2, '0');
 	const fullOffset = `${fullHourOffset}:${fullSecondOffset}`;
 
-	return [ longOffset < 0 ? -1 : 1, Math.abs(longOffset), fullOffset ];
+	return [longOffset < 0 ? -1 : 1, Math.abs(longOffset), fullOffset];
 }
 
 function getTimezoneDate(date: Date, offset: number = 0): Date {
@@ -30,12 +30,12 @@ function getTimezoneDate(date: Date, offset: number = 0): Date {
 }
 
 function getTimezones(date: Date, standard: string = 'GMT') {
-	const [ sign, longOffset, fullOffset ] = getOffsets(date);
+	const [sign, longOffset, fullOffset] = getOffsets(date);
 	const timeSeparator = standard === 'UTC' ? '\u2212' : '-';
-	const fullSeparator = (sign < 0) ? '+' : timeSeparator;
+	const fullSeparator = sign < 0 ? '+' : timeSeparator;
 	const zeroPattern = /^[0:]+$/;
 	return [
-		`${standard}${longOffset ? ((sign < 0) ? '+' : timeSeparator) + longOffset : ''}`,
+		`${standard}${longOffset ? (sign < 0 ? '+' : timeSeparator) + longOffset : ''}`,
 		`${standard}${zeroPattern.test(fullOffset as string) ? '' : fullSeparator + fullOffset}`
 	];
 }
@@ -60,13 +60,13 @@ interface DateOptionsTypes {
 
 type DateOptionsKeys = keyof DateOptionsTypes;
 
-function getDateOptions<T extends DateOptionsKeys>(type: T, timezoneOffset?: number): [
-	DateOptionsTypes[T],
-	DateOptionsTypes[T]
-] {
+function getDateOptions<T extends DateOptionsKeys>(
+	type: T,
+	timezoneOffset?: number
+): [DateOptionsTypes[T], DateOptionsTypes[T]] {
 	const date = getTimezoneDate(new Date(1815, 11, 10, 11, 27), timezoneOffset);
-	const [ gmtLong, gmtFull ] = getTimezones(date);
-	const [ utcLong, utcFull ] = getTimezones(date, 'UTC');
+	const [gmtLong, gmtFull] = getTimezones(date);
+	const [utcLong, utcFull] = getTimezones(date, 'UTC');
 	const values = {
 		en: {
 			date: {
@@ -84,7 +84,7 @@ function getDateOptions<T extends DateOptionsKeys>(type: T, timezoneOffset?: num
 			},
 
 			skeleton: {
-				'GyMMMd': 'Dec 10, 1815 AD'
+				GyMMMd: 'Dec 10, 1815 AD'
 			},
 
 			time: {
@@ -111,7 +111,7 @@ function getDateOptions<T extends DateOptionsKeys>(type: T, timezoneOffset?: num
 			},
 
 			skeleton: {
-				'GyMMMd': '10 déc. 1815 ap. J.-C.'
+				GyMMMd: '10 déc. 1815 ap. J.-C.'
 			},
 
 			time: {
@@ -123,21 +123,23 @@ function getDateOptions<T extends DateOptionsKeys>(type: T, timezoneOffset?: num
 		}
 	};
 
-	const enValues = values[ 'en' ][ type ];
-	const frValues = values[ 'fr' ][ type ];
+	const enValues = values['en'][type];
+	const frValues = values['fr'][type];
 
-	return [ enValues, frValues ];
+	return [enValues, frValues];
 }
 
-function getKeys<T extends DateOptionsKeys>(object: SkeletonOptions | DateOptions, key: T): Array<keyof DateOptionsTypes[T]> {
-	return <any> Object.keys(object);
+function getKeys<T extends DateOptionsKeys>(
+	object: SkeletonOptions | DateOptions,
+	key: T
+): Array<keyof DateOptionsTypes[T]> {
+	return <any>Object.keys(object);
 }
 
 registerSuite('date', {
-
 	before() {
 		// Load the CLDR data for the locales used in the tests ('en' and 'fr');
-		return fetchCldrData([ 'en', 'fr' ]).then(() => {
+		return fetchCldrData(['en', 'fr']).then(() => {
 			switchLocale('en');
 		});
 	},
@@ -160,20 +162,20 @@ registerSuite('date', {
 				assert.strictEqual(formatter(date), '10/12/1815');
 			},
 
-			'with options': (function () {
+			'with options': (function() {
 				function getAssertion<T extends DateOptionsKeys>(type: T, timezoneOffset?: number) {
 					const date = getTimezoneDate(new Date(1815, 11, 10, 11, 27), timezoneOffset);
-					return function () {
-						const [ enValues, frValues ] = getDateOptions(type, timezoneOffset);
+					return function() {
+						const [enValues, frValues] = getDateOptions(type, timezoneOffset);
 
-						getKeys(enValues, type).forEach(key => {
+						getKeys(enValues, type).forEach((key) => {
 							const formatter = getDateFormatter({ [type]: key });
-							assert.strictEqual(formatter(date), enValues[ key ]);
+							assert.strictEqual(formatter(date), enValues[key]);
 						});
 
-						getKeys(frValues, type).forEach(key => {
+						getKeys(frValues, type).forEach((key) => {
 							const formatter = getDateFormatter({ [type]: key }, 'fr');
-							assert.strictEqual(formatter(date), frValues[ key ]);
+							assert.strictEqual(formatter(date), frValues[key]);
 						});
 					};
 				}
@@ -195,10 +197,7 @@ registerSuite('date', {
 
 		getDateParser: {
 			'assert without a locale'() {
-				assert.strictEqual(
-					getDateParser()('12/10/1815').toISOString(),
-					new Date(1815, 11, 10).toISOString()
-				);
+				assert.strictEqual(getDateParser()('12/10/1815').toISOString(), new Date(1815, 11, 10).toISOString());
 			},
 
 			'assert with a locale'() {
@@ -211,21 +210,21 @@ registerSuite('date', {
 			'with options': {
 				'assert "date" option'() {
 					const date = new Date(1815, 11, 10);
-					const [ enValues, frValues ] = getDateOptions('date');
+					const [enValues, frValues] = getDateOptions('date');
 
 					getKeys(enValues, 'date').forEach((key) => {
 						// The expected "short" year format in English is the last two digits,
 						// with the current century assumed.
 						const expected = key === 'short' ? new Date(2015, 11, 10) : date;
 						assert.strictEqual(
-							getDateParser({ date: key })(enValues[ key ]).toISOString(),
+							getDateParser({ date: key })(enValues[key]).toISOString(),
 							expected.toISOString()
 						);
 					});
 
 					getKeys(frValues, 'date').forEach((key) => {
 						assert.strictEqual(
-							getDateParser({ date: key }, 'fr')(frValues[ key ]).toISOString(),
+							getDateParser({ date: key }, 'fr')(frValues[key]).toISOString(),
 							date.toISOString()
 						);
 					});
@@ -238,8 +237,8 @@ registerSuite('date', {
 					expected.setSeconds(0);
 					expected.setMilliseconds(0);
 
-					const [ gmtLong, gmtFull ] = getTimezones(expected);
-					const [ utcLong, utcFull ] = getTimezones(expected, 'UTC');
+					const [gmtLong, gmtFull] = getTimezones(expected);
+					const [utcLong, utcFull] = getTimezones(expected, 'UTC');
 					const enValues = {
 						short: '11:27 AM',
 						medium: '11:27:00 AM',
@@ -255,13 +254,13 @@ registerSuite('date', {
 
 					getKeys(enValues, 'time').forEach((key) => {
 						assert.strictEqual(
-							getDateParser({ time: key })(enValues[ key ]).toISOString(),
+							getDateParser({ time: key })(enValues[key]).toISOString(),
 							expected.toISOString()
 						);
 					});
 					getKeys(frValues, 'time').forEach((key) => {
 						assert.strictEqual(
-							getDateParser({ time: key }, 'fr')(frValues[ key ]).toISOString(),
+							getDateParser({ time: key }, 'fr')(frValues[key]).toISOString(),
 							expected.toISOString()
 						);
 					});
@@ -269,8 +268,8 @@ registerSuite('date', {
 
 				'assert "datetime" option'() {
 					const expected = new Date(2015, 11, 10, 11, 27);
-					const [ gmtLong, gmtFull ] = getTimezones(expected);
-					const [ utcLong, utcFull ] = getTimezones(expected, 'UTC');
+					const [gmtLong, gmtFull] = getTimezones(expected);
+					const [utcLong, utcFull] = getTimezones(expected, 'UTC');
 					const enValues = {
 						short: '12/10/15, 11:27 AM',
 						medium: 'Dec 10, 2015, 11:27:00 AM',
@@ -286,13 +285,13 @@ registerSuite('date', {
 
 					getKeys(enValues, 'datetime').forEach((key) => {
 						assert.strictEqual(
-							getDateParser({ datetime: key })(enValues[ key ]).toISOString(),
+							getDateParser({ datetime: key })(enValues[key]).toISOString(),
 							expected.toISOString()
 						);
 					});
 					getKeys(frValues, 'datetime').forEach((key) => {
 						assert.strictEqual(
-							getDateParser({ datetime: key }, 'fr')(frValues[ key ]).toISOString(),
+							getDateParser({ datetime: key }, 'fr')(frValues[key]).toISOString(),
 							expected.toISOString()
 						);
 					});
@@ -300,16 +299,16 @@ registerSuite('date', {
 
 				'assert "skeleton" option'() {
 					const expected = new Date(1815, 11, 10).toISOString();
-					const [ enValues, frValues ] = getDateOptions('skeleton');
+					const [enValues, frValues] = getDateOptions('skeleton');
 
 					getKeys(enValues, 'skeleton').forEach((key) => {
 						const parser = getDateParser({ skeleton: 'GyMMMd' });
-						assert.strictEqual(parser(enValues[ key ]).toISOString(), expected);
+						assert.strictEqual(parser(enValues[key]).toISOString(), expected);
 					});
 
 					getKeys(enValues, 'skeleton').forEach((key) => {
 						const parser = getDateParser({ skeleton: 'GyMMMd' }, 'fr');
-						assert.strictEqual(parser(frValues[ key ]).toISOString(), expected);
+						assert.strictEqual(parser(frValues[key]).toISOString(), expected);
 					});
 				}
 			}
@@ -324,18 +323,18 @@ registerSuite('date', {
 				assert.strictEqual(formatDate(new Date(1815, 11, 10), 'fr'), '10/12/1815');
 			},
 
-			'assert options': (function () {
+			'assert options': (function() {
 				function getAssertion<T extends DateOptionsKeys>(type: T, timezoneOffset?: number) {
 					const date = getTimezoneDate(new Date(1815, 11, 10, 11, 27), timezoneOffset);
 
-					return function () {
-						const [ enValues, frValues ] = getDateOptions(type, timezoneOffset);
+					return function() {
+						const [enValues, frValues] = getDateOptions(type, timezoneOffset);
 
 						getKeys(enValues, type).forEach((key) => {
-							assert.strictEqual(formatDate(date, { [type]: key }), enValues[ key ]);
+							assert.strictEqual(formatDate(date, { [type]: key }), enValues[key]);
 						});
 						getKeys(frValues, type).forEach((key) => {
-							assert.strictEqual(formatDate(date, { [type]: key }, 'fr'), frValues[ key ]);
+							assert.strictEqual(formatDate(date, { [type]: key }, 'fr'), frValues[key]);
 						});
 					};
 				}
@@ -398,37 +397,31 @@ registerSuite('date', {
 
 		parseDate: {
 			'assert without a locale'() {
-				assert.strictEqual(
-					parseDate('12/10/1815').toISOString(),
-					new Date(1815, 11, 10).toISOString()
-				);
+				assert.strictEqual(parseDate('12/10/1815').toISOString(), new Date(1815, 11, 10).toISOString());
 			},
 
 			'assert with a locale'() {
-				assert.strictEqual(
-					parseDate('10/12/1815', 'fr').toISOString(),
-					new Date(1815, 11, 10).toISOString()
-				);
+				assert.strictEqual(parseDate('10/12/1815', 'fr').toISOString(), new Date(1815, 11, 10).toISOString());
 			},
 
 			'with options': {
 				'assert "date" option'() {
 					const date = new Date(1815, 11, 10);
-					const [ enValues, frValues ] = getDateOptions('date');
+					const [enValues, frValues] = getDateOptions('date');
 
 					getKeys(enValues, 'date').forEach((key) => {
 						// The expected "short" year format in English is the last two digits,
 						// with the current century assumed.
 						const expected = key === 'short' ? new Date(2015, 11, 10) : date;
 						assert.strictEqual(
-							parseDate(enValues[ key ], { date: key }).toISOString(),
+							parseDate(enValues[key], { date: key }).toISOString(),
 							expected.toISOString()
 						);
 					});
 
 					getKeys(frValues, 'date').forEach((key) => {
 						assert.strictEqual(
-							parseDate(frValues[ key ], { date: key }, 'fr').toISOString(),
+							parseDate(frValues[key], { date: key }, 'fr').toISOString(),
 							date.toISOString()
 						);
 					});
@@ -441,8 +434,8 @@ registerSuite('date', {
 					expected.setSeconds(0);
 					expected.setMilliseconds(0);
 
-					const [ gmtLong, gmtFull ] = getTimezones(expected);
-					const [ utcLong, utcFull ] = getTimezones(expected, 'UTC');
+					const [gmtLong, gmtFull] = getTimezones(expected);
+					const [utcLong, utcFull] = getTimezones(expected, 'UTC');
 					const enValues = {
 						short: '11:27 AM',
 						medium: '11:27:00 AM',
@@ -458,13 +451,13 @@ registerSuite('date', {
 
 					getKeys(enValues, 'time').forEach((key) => {
 						assert.strictEqual(
-							parseDate((<any> enValues)[ key ], { time: key }).toISOString(),
+							parseDate((<any>enValues)[key], { time: key }).toISOString(),
 							expected.toISOString()
 						);
 					});
 					getKeys(frValues, 'time').forEach((key) => {
 						assert.strictEqual(
-							parseDate((<any> frValues)[ key ], { time: key }, 'fr').toISOString(),
+							parseDate((<any>frValues)[key], { time: key }, 'fr').toISOString(),
 							expected.toISOString()
 						);
 					});
@@ -472,8 +465,8 @@ registerSuite('date', {
 
 				'assert "datetime" option'() {
 					const expected = new Date(2015, 11, 10, 11, 27);
-					const [ gmtLong, gmtFull ] = getTimezones(expected);
-					const [ utcLong, utcFull ] = getTimezones(expected, 'UTC');
+					const [gmtLong, gmtFull] = getTimezones(expected);
+					const [utcLong, utcFull] = getTimezones(expected, 'UTC');
 					const enValues = {
 						short: '12/10/15, 11:27 AM',
 						medium: 'Dec 10, 2015, 11:27:00 AM',
@@ -489,13 +482,13 @@ registerSuite('date', {
 
 					getKeys(enValues, 'datetime').forEach((key) => {
 						assert.strictEqual(
-							parseDate((<any> enValues)[ key ], { datetime: key }).toISOString(),
+							parseDate((<any>enValues)[key], { datetime: key }).toISOString(),
 							expected.toISOString()
 						);
 					});
 					getKeys(frValues, 'datetime').forEach((key) => {
 						assert.strictEqual(
-							parseDate((<any> frValues)[ key ], { datetime: key }, 'fr').toISOString(),
+							parseDate((<any>frValues)[key], { datetime: key }, 'fr').toISOString(),
 							expected.toISOString()
 						);
 					});
@@ -503,14 +496,17 @@ registerSuite('date', {
 
 				'assert "skeleton" option'() {
 					const expected = new Date(1815, 11, 10).toISOString();
-					const [ enValues, frValues ] = getDateOptions('skeleton');
+					const [enValues, frValues] = getDateOptions('skeleton');
 
 					getKeys(enValues, 'skeleton').forEach((key) => {
-						assert.strictEqual(parseDate(enValues[ key ], { skeleton: 'GyMMMd' }).toISOString(), expected);
+						assert.strictEqual(parseDate(enValues[key], { skeleton: 'GyMMMd' }).toISOString(), expected);
 					});
 
 					getKeys(enValues, 'skeleton').forEach((key) => {
-						assert.strictEqual(parseDate(frValues[ key ], { skeleton: 'GyMMMd' }, 'fr').toISOString(), expected);
+						assert.strictEqual(
+							parseDate(frValues[key], { skeleton: 'GyMMMd' }, 'fr').toISOString(),
+							expected
+						);
 					});
 				}
 			}

--- a/tests/unit/i18n.ts
+++ b/tests/unit/i18n.ts
@@ -22,16 +22,15 @@ import bundle from '../support/mocks/common/main';
 import partyBundle from '../support/mocks/common/party';
 
 registerSuite('i18n', {
-
 	before() {
 		// Load the CLDR data for the locales used in the tests ('en' and 'fr');
-		return fetchCldrData([ 'en', 'fr' ]).then(() => {
+		return fetchCldrData(['en', 'fr']).then(() => {
 			switchLocale('en');
 		});
 	},
 
 	afterEach() {
-		const loadCldrData = <any> cldrLoad.default;
+		const loadCldrData = <any>cldrLoad.default;
 		if (typeof loadCldrData.restore === 'function') {
 			loadCldrData.restore();
 		}
@@ -41,15 +40,13 @@ registerSuite('i18n', {
 	},
 
 	tests: {
-
 		systemLocale() {
 			let expected = 'en';
 
 			if (has('host-browser')) {
 				const navigator = global.navigator;
 				expected = navigator.language || navigator.userLanguage;
-			}
-			else if (has('host-node')) {
+			} else if (has('host-node')) {
 				expected = process.env.LANG || expected;
 			}
 
@@ -63,14 +60,18 @@ registerSuite('i18n', {
 				},
 
 				after() {
-					return fetchCldrData([ 'en', 'fr' ]);
+					return fetchCldrData(['en', 'fr']);
 				},
 
 				tests: {
 					'assert without loaded messages'() {
-						assert.throws(() => {
-							formatMessage({ messages: {} }, 'messageKey');
-						}, Error, 'The bundle has not been registered.');
+						assert.throws(
+							() => {
+								formatMessage({ messages: {} }, 'messageKey');
+							},
+							Error,
+							'The bundle has not been registered.'
+						);
 					},
 
 					'assert tokens replaced'() {
@@ -81,11 +82,15 @@ registerSuite('i18n', {
 							});
 							assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
 
-							assert.throws(() => {
-								formatMessage(partyBundle, 'simpleGuestInfo', {
-									host: 'Nita'
-								});
-							}, Error, 'Missing property guest');
+							assert.throws(
+								() => {
+									formatMessage(partyBundle, 'simpleGuestInfo', {
+										host: 'Nita'
+									});
+								},
+								Error,
+								'Missing property guest'
+							);
 						});
 					},
 
@@ -162,11 +167,15 @@ registerSuite('i18n', {
 
 			'assert supported locale'() {
 				return i18n(bundle, 'ar').then(() => {
-					assert.deepEqual(getCachedMessages(bundle, 'ar'), {
-						hello: 'السلام عليكم',
-						helloReply: 'و عليكم السام',
-						goodbye: 'مع السلامة'
-					}, 'Locale messages can be retrieved with a bundle object.');
+					assert.deepEqual(
+						getCachedMessages(bundle, 'ar'),
+						{
+							hello: 'السلام عليكم',
+							helloReply: 'و عليكم السام',
+							goodbye: 'مع السلامة'
+						},
+						'Locale messages can be retrieved with a bundle object.'
+					);
 				});
 			},
 
@@ -180,15 +189,21 @@ registerSuite('i18n', {
 				setLocaleMessages(bundle, messages, 'en-GB');
 
 				const cached = getCachedMessages(bundle, 'en-GB');
-				assert.deepEqual(cached, assign({}, bundle.messages, messages),
-					'Messages added with `setLocaleMessages` are returned.');
+				assert.deepEqual(
+					cached,
+					assign({}, bundle.messages, messages),
+					'Messages added with `setLocaleMessages` are returned.'
+				);
 			},
 
 			'assert most specific supported locale returned'() {
 				return i18n(bundle, 'ar').then(() => {
 					const cached = getCachedMessages(bundle, 'ar');
-					assert.deepEqual(getCachedMessages(bundle, 'ar-IR'), cached,
-						'Messages are returned for the most specific supported locale.');
+					assert.deepEqual(
+						getCachedMessages(bundle, 'ar-IR'),
+						cached,
+						'Messages are returned for the most specific supported locale.'
+					);
 				});
 			}
 		},
@@ -200,14 +215,18 @@ registerSuite('i18n', {
 				},
 
 				after() {
-					return fetchCldrData([ 'en', 'fr' ]);
+					return fetchCldrData(['en', 'fr']);
 				},
 
 				tests: {
 					'assert without loaded messages'() {
-						assert.throws(() => {
-							getMessageFormatter({ messages: {} }, 'messageKey')();
-						}, Error, 'The bundle has not been registered.');
+						assert.throws(
+							() => {
+								getMessageFormatter({ messages: {} }, 'messageKey')();
+							},
+							Error,
+							'The bundle has not been registered.'
+						);
 					},
 
 					'assert tokens replaced'() {
@@ -219,11 +238,15 @@ registerSuite('i18n', {
 							});
 							assert.strictEqual(formatted, 'Nita invites Bryan to a party.');
 
-							assert.throws(() => {
-								formatter({
-									host: 'Nita'
-								});
-							}, Error, 'Missing property guest');
+							assert.throws(
+								() => {
+									formatter({
+										host: 'Nita'
+									});
+								},
+								Error,
+								'Missing property guest'
+							);
 						});
 					},
 
@@ -290,7 +313,7 @@ registerSuite('i18n', {
 
 		i18n: {
 			'assert system locale used as default'() {
-				return i18n(bundle).then(function (messages: Messages) {
+				return i18n(bundle).then(function(messages: Messages) {
 					assert.deepEqual(messages, {
 						hello: 'Hello',
 						helloReply: 'Hello',
@@ -300,38 +323,50 @@ registerSuite('i18n', {
 			},
 
 			'assert with string locale'() {
-				return i18n(bundle, 'ar').then(function (messages: Messages) {
-					assert.deepEqual(messages, {
-						hello: 'السلام عليكم',
-						helloReply: 'و عليكم السام',
-						goodbye: 'مع السلامة'
-					}, 'Locale dictionary is used.');
+				return i18n(bundle, 'ar').then(function(messages: Messages) {
+					assert.deepEqual(
+						messages,
+						{
+							hello: 'السلام عليكم',
+							helloReply: 'و عليكم السام',
+							goodbye: 'مع السلامة'
+						},
+						'Locale dictionary is used.'
+					);
 				});
 			},
 
 			'assert with nested locale'() {
-				return i18n(bundle, 'ar-JO').then(function (messages: Messages) {
+				return i18n(bundle, 'ar-JO').then(function(messages: Messages) {
 					// ar-JO is missing "goodbye" key
-					assert.deepEqual(messages, {
-						hello: 'مرحبا',
-						helloReply: 'مرحبتين',
-						goodbye: 'مع السلامة'
-					}, 'Most specific dictionary is used with fallbacks provided.');
+					assert.deepEqual(
+						messages,
+						{
+							hello: 'مرحبا',
+							helloReply: 'مرحبتين',
+							goodbye: 'مع السلامة'
+						},
+						'Most specific dictionary is used with fallbacks provided.'
+					);
 				});
 			},
 
 			'assert with invalid locale'() {
-				return i18n(bundle, 'ar-JO-').then(function (messages: Messages) {
-					assert.deepEqual(messages, {
-						hello: 'مرحبا',
-						helloReply: 'مرحبتين',
-						goodbye: 'مع السلامة'
-					}, 'Only non-empty locale segments are considered.');
+				return i18n(bundle, 'ar-JO-').then(function(messages: Messages) {
+					assert.deepEqual(
+						messages,
+						{
+							hello: 'مرحبا',
+							helloReply: 'مرحبتين',
+							goodbye: 'مع السلامة'
+						},
+						'Only non-empty locale segments are considered.'
+					);
 				});
 			},
 
 			'assert unsupported locale'() {
-				return i18n(bundle, 'fr-CA').then(function (messages: Messages) {
+				return i18n(bundle, 'fr-CA').then(function(messages: Messages) {
 					assert.deepEqual(messages, {
 						hello: 'Hello',
 						helloReply: 'Hello',
@@ -344,31 +379,37 @@ registerSuite('i18n', {
 				const { messages } = bundle;
 				const localeless = { messages };
 
-				return i18n(localeless, 'ar').then(function (messages: Messages) {
-					assert.deepEqual(messages, {
-						hello: 'Hello',
-						helloReply: 'Hello',
-						goodbye: 'Goodbye'
-					}, 'Default messages returned when bundle provides no locales.');
+				return i18n(localeless, 'ar').then(function(messages: Messages) {
+					assert.deepEqual(
+						messages,
+						{
+							hello: 'Hello',
+							helloReply: 'Hello',
+							goodbye: 'Goodbye'
+						},
+						'Default messages returned when bundle provides no locales.'
+					);
 				});
 			},
 
 			'assert messages cached'() {
-				return i18n(bundle, 'ar-JO').then(function () {
-					return i18n(bundle, 'ar-JO');
-				}).then((messages: Messages) => {
-					const cached = getCachedMessages(bundle, 'ar-JO');
+				return i18n(bundle, 'ar-JO')
+					.then(function() {
+						return i18n(bundle, 'ar-JO');
+					})
+					.then((messages: Messages) => {
+						const cached = getCachedMessages(bundle, 'ar-JO');
 
-					assert.strictEqual(cached, messages as any, 'Message dictionaries are cached.');
-				});
+						assert.strictEqual(cached, messages as any, 'Message dictionaries are cached.');
+					});
 			},
 
 			'assert message dictionaries are frozen'() {
-				return i18n(bundle, 'ar-JO').then(function () {
+				return i18n(bundle, 'ar-JO').then(function() {
 					const cached = getCachedMessages(bundle, 'ar-JO');
 
 					assert.throws(() => {
-						cached![ 'hello' ] = 'Hello';
+						cached!['hello'] = 'Hello';
 					});
 				});
 			}
@@ -378,7 +419,10 @@ registerSuite('i18n', {
 			'assert with a bundle'() {
 				return i18n(bundle, 'ar').then((messages: Messages) => {
 					invalidate(bundle);
-					assert.isUndefined(getCachedMessages(bundle, 'ar'), 'The cache is invalidated for the specified bundle.');
+					assert.isUndefined(
+						getCachedMessages(bundle, 'ar'),
+						'The cache is invalidated for the specified bundle.'
+					);
 				});
 			},
 
@@ -421,18 +465,24 @@ registerSuite('i18n', {
 			setLocaleMessages(bundle, czech, 'cz');
 
 			const path = '..-_build-tests-support-mocks-common-main';
-			const first = (<any> Globalize).loadMessages.args[ 0 ][ 0 ].fr[ path ];
-			const second = (<any> Globalize).loadMessages.args[ 1 ][ 0 ].cz[ path ];
+			const first = (<any>Globalize).loadMessages.args[0][0].fr[path];
+			const second = (<any>Globalize).loadMessages.args[1][0].cz[path];
 
 			assert.isFrozen(first, 'locale messages should be frozen');
 			assert.isFrozen(second, 'locale messages should be frozen');
 
-			assert.deepEqual(getCachedMessages(bundle, 'fr'), assign({}, french, <any> { helloReply: 'Hello' }),
-				'Default messages should be included where not overridden');
-			assert.deepEqual(getCachedMessages(bundle, 'cz'), assign({}, czech, <any> { helloReply: 'Hello' }),
-				'Default messages should be included where not overridden');
+			assert.deepEqual(
+				getCachedMessages(bundle, 'fr'),
+				assign({}, french, <any>{ helloReply: 'Hello' }),
+				'Default messages should be included where not overridden'
+			);
+			assert.deepEqual(
+				getCachedMessages(bundle, 'cz'),
+				assign({}, czech, <any>{ helloReply: 'Hello' }),
+				'Default messages should be included where not overridden'
+			);
 
-			(<any> Globalize).loadMessages.restore();
+			(<any>Globalize).loadMessages.restore();
 		},
 
 		switchLocale: {
@@ -456,18 +506,28 @@ registerSuite('i18n', {
 			'assert new locale passed to Globalize'() {
 				sinon.spy(Globalize, 'locale');
 
-				return fetchCldrData([ 'fr' ]).then(() => {
-					switchLocale('fr');
-					assert.isTrue((<any> Globalize).locale.calledWith('fr'), 'Locale should be passed to Globalize.');
+				return fetchCldrData(['fr']).then(
+					() => {
+						switchLocale('fr');
+						assert.isTrue(
+							(<any>Globalize).locale.calledWith('fr'),
+							'Locale should be passed to Globalize.'
+						);
 
-					cldrLoad.reset();
-					switchLocale('en');
-					assert.strictEqual((<any> Globalize).locale.callCount, 1, 'Locale should not be passed to Globalize.');
-					(<any> Globalize).locale.restore();
-				}, (error: Error) => {
-					(<any> Globalize).locale.restore();
-					throw error;
-				});
+						cldrLoad.reset();
+						switchLocale('en');
+						assert.strictEqual(
+							(<any>Globalize).locale.callCount,
+							1,
+							'Locale should not be passed to Globalize.'
+						);
+						(<any>Globalize).locale.restore();
+					},
+					(error: Error) => {
+						(<any>Globalize).locale.restore();
+						throw error;
+					}
+				);
 			}
 		},
 

--- a/tests/unit/number.ts
+++ b/tests/unit/number.ts
@@ -16,7 +16,7 @@ import { switchLocale, systemLocale } from '../../src/i18n';
 registerSuite('number', {
 	before() {
 		// Load the CLDR data for the locales used in the tests ('en' and 'fr');
-		return fetchCldrData([ 'en', 'fr' ]).then(() => {
+		return fetchCldrData(['en', 'fr']).then(() => {
 			switchLocale('en');
 		});
 	},
@@ -50,23 +50,35 @@ registerSuite('number', {
 				assert.strictEqual(formatNumber(12.37, { minimumFractionDigits: 3 }), '12.370');
 				assert.strictEqual(formatNumber(12.37, { maximumFractionDigits: 1 }), '12.4');
 				assert.strictEqual(formatNumber(12.33, { maximumFractionDigits: 1 }), '12.3');
-				assert.strictEqual(formatNumber(12.37, {
-					minimumSignificantDigits: 3,
-					maximumSignificantDigits: 5
-				}), '12.37');
+				assert.strictEqual(
+					formatNumber(12.37, {
+						minimumSignificantDigits: 3,
+						maximumSignificantDigits: 5
+					}),
+					'12.37'
+				);
 
-				assert.strictEqual(formatNumber(12.33, {
-					maximumFractionDigits: 1,
-					round: 'ceil'
-				}), '12.4');
-				assert.strictEqual(formatNumber(12.33, {
-					maximumFractionDigits: 1,
-					round: 'floor'
-				}), '12.3');
-				assert.strictEqual(formatNumber(12.33, {
-					maximumFractionDigits: 1,
-					round: 'truncate'
-				}), '12.3');
+				assert.strictEqual(
+					formatNumber(12.33, {
+						maximumFractionDigits: 1,
+						round: 'ceil'
+					}),
+					'12.4'
+				);
+				assert.strictEqual(
+					formatNumber(12.33, {
+						maximumFractionDigits: 1,
+						round: 'floor'
+					}),
+					'12.3'
+				);
+				assert.strictEqual(
+					formatNumber(12.33, {
+						maximumFractionDigits: 1,
+						round: 'truncate'
+					}),
+					'12.3'
+				);
 
 				assert.strictEqual(formatNumber(1234567890), '1,234,567,890');
 				assert.strictEqual(formatNumber(1234567890, { useGrouping: false }), '1234567890');
@@ -79,23 +91,51 @@ registerSuite('number', {
 				assert.strictEqual(formatNumber(12.37, { minimumFractionDigits: 3 }, 'fr'), '12,370');
 				assert.strictEqual(formatNumber(12.37, { maximumFractionDigits: 1 }, 'fr'), '12,4');
 				assert.strictEqual(formatNumber(12.33, { maximumFractionDigits: 1 }, 'fr'), '12,3');
-				assert.strictEqual(formatNumber(12.37, {
-					minimumSignificantDigits: 3,
-					maximumSignificantDigits: 5
-				}, 'fr'), '12,37');
+				assert.strictEqual(
+					formatNumber(
+						12.37,
+						{
+							minimumSignificantDigits: 3,
+							maximumSignificantDigits: 5
+						},
+						'fr'
+					),
+					'12,37'
+				);
 
-				assert.strictEqual(formatNumber(12.33, {
-					maximumFractionDigits: 1,
-					round: 'ceil'
-				}, 'fr'), '12,4');
-				assert.strictEqual(formatNumber(12.33, {
-					maximumFractionDigits: 1,
-					round: 'floor'
-				}, 'fr'), '12,3');
-				assert.strictEqual(formatNumber(12.33, {
-					maximumFractionDigits: 1,
-					round: 'truncate'
-				}, 'fr'), '12,3');
+				assert.strictEqual(
+					formatNumber(
+						12.33,
+						{
+							maximumFractionDigits: 1,
+							round: 'ceil'
+						},
+						'fr'
+					),
+					'12,4'
+				);
+				assert.strictEqual(
+					formatNumber(
+						12.33,
+						{
+							maximumFractionDigits: 1,
+							round: 'floor'
+						},
+						'fr'
+					),
+					'12,3'
+				);
+				assert.strictEqual(
+					formatNumber(
+						12.33,
+						{
+							maximumFractionDigits: 1,
+							round: 'truncate'
+						},
+						'fr'
+					),
+					'12,3'
+				);
 
 				assert.strictEqual(formatNumber(1234567890, 'fr'), '1\u00A0234\u00A0567\u00A0890');
 				assert.strictEqual(formatNumber(1234567890, { useGrouping: false }, 'fr'), '1234567890');
@@ -126,23 +166,35 @@ registerSuite('number', {
 				assert.strictEqual(getNumberFormatter({ minimumFractionDigits: 3 })(12.37), '12.370');
 				assert.strictEqual(getNumberFormatter({ maximumFractionDigits: 1 })(12.37), '12.4');
 				assert.strictEqual(getNumberFormatter({ maximumFractionDigits: 1 })(12.33), '12.3');
-				assert.strictEqual(getNumberFormatter({
-					minimumSignificantDigits: 3,
-					maximumSignificantDigits: 5
-				})(12.37), '12.37');
+				assert.strictEqual(
+					getNumberFormatter({
+						minimumSignificantDigits: 3,
+						maximumSignificantDigits: 5
+					})(12.37),
+					'12.37'
+				);
 
-				assert.strictEqual(getNumberFormatter({
-					maximumFractionDigits: 1,
-					round: 'ceil'
-				})(12.33), '12.4');
-				assert.strictEqual(getNumberFormatter({
-					maximumFractionDigits: 1,
-					round: 'floor'
-				})(12.33), '12.3');
-				assert.strictEqual(getNumberFormatter({
-					maximumFractionDigits: 1,
-					round: 'truncate'
-				})(12.33), '12.3');
+				assert.strictEqual(
+					getNumberFormatter({
+						maximumFractionDigits: 1,
+						round: 'ceil'
+					})(12.33),
+					'12.4'
+				);
+				assert.strictEqual(
+					getNumberFormatter({
+						maximumFractionDigits: 1,
+						round: 'floor'
+					})(12.33),
+					'12.3'
+				);
+				assert.strictEqual(
+					getNumberFormatter({
+						maximumFractionDigits: 1,
+						round: 'truncate'
+					})(12.33),
+					'12.3'
+				);
 
 				assert.strictEqual(getNumberFormatter()(1234567890), '1,234,567,890');
 				assert.strictEqual(getNumberFormatter({ useGrouping: false })(1234567890), '1234567890');
@@ -155,23 +207,47 @@ registerSuite('number', {
 				assert.strictEqual(getNumberFormatter({ minimumFractionDigits: 3 }, 'fr')(12.37), '12,370');
 				assert.strictEqual(getNumberFormatter({ maximumFractionDigits: 1 }, 'fr')(12.37), '12,4');
 				assert.strictEqual(getNumberFormatter({ maximumFractionDigits: 1 }, 'fr')(12.33), '12,3');
-				assert.strictEqual(getNumberFormatter({
-					minimumSignificantDigits: 3,
-					maximumSignificantDigits: 5
-				}, 'fr')(12.37), '12,37');
+				assert.strictEqual(
+					getNumberFormatter(
+						{
+							minimumSignificantDigits: 3,
+							maximumSignificantDigits: 5
+						},
+						'fr'
+					)(12.37),
+					'12,37'
+				);
 
-				assert.strictEqual(getNumberFormatter({
-					maximumFractionDigits: 1,
-					round: 'ceil'
-				}, 'fr')(12.33), '12,4');
-				assert.strictEqual(getNumberFormatter({
-					maximumFractionDigits: 1,
-					round: 'floor'
-				}, 'fr')(12.33), '12,3');
-				assert.strictEqual(getNumberFormatter({
-					maximumFractionDigits: 1,
-					round: 'truncate'
-				}, 'fr')(12.33), '12,3');
+				assert.strictEqual(
+					getNumberFormatter(
+						{
+							maximumFractionDigits: 1,
+							round: 'ceil'
+						},
+						'fr'
+					)(12.33),
+					'12,4'
+				);
+				assert.strictEqual(
+					getNumberFormatter(
+						{
+							maximumFractionDigits: 1,
+							round: 'floor'
+						},
+						'fr'
+					)(12.33),
+					'12,3'
+				);
+				assert.strictEqual(
+					getNumberFormatter(
+						{
+							maximumFractionDigits: 1,
+							round: 'truncate'
+						},
+						'fr'
+					)(12.33),
+					'12,3'
+				);
 
 				assert.strictEqual(getNumberFormatter('fr')(1234567890), '1\u00A0234\u00A0567\u00A0890');
 				assert.strictEqual(getNumberFormatter({ useGrouping: false }, 'fr')(1234567890), '1234567890');

--- a/tests/unit/unit.ts
+++ b/tests/unit/unit.ts
@@ -8,7 +8,7 @@ import { switchLocale, systemLocale } from '../../src/i18n';
 registerSuite('number units', {
 	before() {
 		// Load the CLDR data for the locales used in the tests ('en' and 'fr');
-		return fetchCldrData([ 'en', 'fr' ]).then(() => {
+		return fetchCldrData(['en', 'fr']).then(() => {
 			switchLocale('en');
 		});
 	},
@@ -28,9 +28,12 @@ registerSuite('number units', {
 				assert.strictEqual(formatUnit(5280, 'foot', { form: 'short' }), '5,280 ft');
 				assert.strictEqual(formatUnit(1, 'foot', { form: 'narrow' }), '1′');
 				assert.strictEqual(formatUnit(5280, 'foot', { form: 'narrow' }), '5,280′');
-				assert.strictEqual(formatUnit(5280, 'foot', {
-					numberFormatter: getNumberFormatter({ useGrouping: false })
-				}), '5280 feet');
+				assert.strictEqual(
+					formatUnit(5280, 'foot', {
+						numberFormatter: getNumberFormatter({ useGrouping: false })
+					}),
+					'5280 feet'
+				);
 			},
 
 			'assert with a locale'() {
@@ -42,9 +45,17 @@ registerSuite('number units', {
 				assert.strictEqual(formatUnit(1000, 'meter', { form: 'short' }, 'fr'), '1\u00A0000 m');
 				assert.strictEqual(formatUnit(1, 'meter', { form: 'narrow' }, 'fr'), '1m');
 				assert.strictEqual(formatUnit(1000, 'meter', { form: 'narrow' }, 'fr'), '1\u00A0000m');
-				assert.strictEqual(formatUnit(1000, 'meter', {
-					numberFormatter: getNumberFormatter({ useGrouping: false })
-				}, 'fr'), '1000 mètres');
+				assert.strictEqual(
+					formatUnit(
+						1000,
+						'meter',
+						{
+							numberFormatter: getNumberFormatter({ useGrouping: false })
+						},
+						'fr'
+					),
+					'1000 mètres'
+				);
 			}
 		},
 
@@ -58,9 +69,12 @@ registerSuite('number units', {
 				assert.strictEqual(getUnitFormatter('foot', { form: 'short' })(5280), '5,280 ft');
 				assert.strictEqual(getUnitFormatter('foot', { form: 'narrow' })(1), '1′');
 				assert.strictEqual(getUnitFormatter('foot', { form: 'narrow' })(5280), '5,280′');
-				assert.strictEqual(getUnitFormatter('foot', {
-					numberFormatter: getNumberFormatter({ useGrouping: false })
-				})(5280), '5280 feet');
+				assert.strictEqual(
+					getUnitFormatter('foot', {
+						numberFormatter: getNumberFormatter({ useGrouping: false })
+					})(5280),
+					'5280 feet'
+				);
 			},
 
 			'assert with a locale'() {
@@ -72,9 +86,16 @@ registerSuite('number units', {
 				assert.strictEqual(getUnitFormatter('meter', { form: 'short' }, 'fr')(1000), '1\u00A0000 m');
 				assert.strictEqual(getUnitFormatter('meter', { form: 'narrow' }, 'fr')(1), '1m');
 				assert.strictEqual(getUnitFormatter('meter', { form: 'narrow' }, 'fr')(1000), '1\u00A0000m');
-				assert.strictEqual(getUnitFormatter('meter', {
-					numberFormatter: getNumberFormatter({ useGrouping: false })
-				}, 'fr')(1000), '1000 mètres');
+				assert.strictEqual(
+					getUnitFormatter(
+						'meter',
+						{
+							numberFormatter: getNumberFormatter({ useGrouping: false })
+						},
+						'fr'
+					)(1000),
+					'1000 mètres'
+				);
 			}
 		}
 	}

--- a/tests/unit/util/globalize.ts
+++ b/tests/unit/util/globalize.ts
@@ -10,9 +10,8 @@ import { switchLocale, systemLocale } from '../../../src/i18n';
 import getGlobalize, { globalizeDelegator } from '../../../src/util/globalize';
 
 registerSuite('util/globalize', {
-
 	before() {
-		return fetchCldrData([ 'en', 'fr' ]).then(() => {
+		return fetchCldrData(['en', 'fr']).then(() => {
 			switchLocale('en');
 			switchLocale('en');
 		});
@@ -23,7 +22,6 @@ registerSuite('util/globalize', {
 	},
 
 	tests: {
-
 		getGlobalize() {
 			assert.strictEqual(getGlobalize(), Globalize, 'The main globalize object is returned.');
 			assert.instanceOf(getGlobalize('fr'), Globalize, 'A Globalize instance is returned.');
@@ -37,15 +35,21 @@ registerSuite('util/globalize', {
 				const options: DateFormatterOptions = { datetime: 'full' };
 
 				assert.strictEqual(globalizeDelegator('formatDate', { value }), Globalize.formatDate(value));
-				assert.strictEqual(globalizeDelegator('formatDate', {
-					optionsOrLocale: options,
-					value
-				}), Globalize.formatDate(value, options));
-				assert.strictEqual(globalizeDelegator('formatDate', {
-					locale,
-					optionsOrLocale: options,
-					value
-				}), new Globalize('fr').formatDate(value, options));
+				assert.strictEqual(
+					globalizeDelegator('formatDate', {
+						optionsOrLocale: options,
+						value
+					}),
+					Globalize.formatDate(value, options)
+				);
+				assert.strictEqual(
+					globalizeDelegator('formatDate', {
+						locale,
+						optionsOrLocale: options,
+						value
+					}),
+					new Globalize('fr').formatDate(value, options)
+				);
 			},
 
 			'assert method that takes a value and a unit'() {
@@ -54,21 +58,30 @@ registerSuite('util/globalize', {
 				const value = 5;
 				const options: RelativeTimeFormatterOptions = { form: 'short' };
 
-				assert.strictEqual(globalizeDelegator('formatRelativeTime', {
-					unit,
-					value
-				}), Globalize.formatRelativeTime(value, unit));
-				assert.strictEqual(globalizeDelegator('formatRelativeTime', {
-					optionsOrLocale: options,
-					unit,
-					value
-				}), Globalize.formatRelativeTime(value, unit, options));
-				assert.strictEqual(globalizeDelegator('formatRelativeTime', {
-					locale,
-					optionsOrLocale: options,
-					unit,
-					value
-				}), new Globalize('fr').formatRelativeTime(value, unit, options));
+				assert.strictEqual(
+					globalizeDelegator('formatRelativeTime', {
+						unit,
+						value
+					}),
+					Globalize.formatRelativeTime(value, unit)
+				);
+				assert.strictEqual(
+					globalizeDelegator('formatRelativeTime', {
+						optionsOrLocale: options,
+						unit,
+						value
+					}),
+					Globalize.formatRelativeTime(value, unit, options)
+				);
+				assert.strictEqual(
+					globalizeDelegator('formatRelativeTime', {
+						locale,
+						optionsOrLocale: options,
+						unit,
+						value
+					}),
+					new Globalize('fr').formatRelativeTime(value, unit, options)
+				);
 			},
 
 			'assert method returns a method'() {

--- a/tests/unit/util/main.ts
+++ b/tests/unit/util/main.ts
@@ -3,40 +3,53 @@ const { assert } = intern.getPlugin('chai');
 import { generateLocales, normalizeLocale, validateLocale } from '../../../src/util/main';
 
 registerSuite('util/main', {
-
 	generateLocales() {
-		assert.sameMembers(generateLocales('en'), [ 'en' ]);
-		assert.sameMembers(generateLocales('en-US'), [ 'en', 'en-US' ]);
-		assert.sameMembers(generateLocales('en-US-POSIX'), [ 'en', 'en-US', 'en-US-POSIX' ]);
+		assert.sameMembers(generateLocales('en'), ['en']);
+		assert.sameMembers(generateLocales('en-US'), ['en', 'en-US']);
+		assert.sameMembers(generateLocales('en-US-POSIX'), ['en', 'en-US', 'en-US-POSIX']);
 
-		assert.sameMembers(generateLocales('en_US.UTF8'), [ 'en', 'en-US' ],
-			'Node-style locales are normalize.');
-		assert.sameMembers(generateLocales('en_US_POSIX.UTF8'), [ 'en', 'en-US', 'en-US-POSIX' ],
-			'Node-style locales are normalize.');
+		assert.sameMembers(generateLocales('en_US.UTF8'), ['en', 'en-US'], 'Node-style locales are normalize.');
+		assert.sameMembers(
+			generateLocales('en_US_POSIX.UTF8'),
+			['en', 'en-US', 'en-US-POSIX'],
+			'Node-style locales are normalize.'
+		);
 
-		assert.sameMembers(generateLocales('en-'), [ 'en' ], 'Trailing hyphens are removed.');
-		assert.sameMembers(generateLocales('en-.UTF8'), [ 'en' ], 'Trailing hyphens are removed.');
-		assert.sameMembers(generateLocales('en_'), [ 'en' ], 'Trailing underscores are removed.');
-		assert.sameMembers(generateLocales('en_.UTF8'), [ 'en' ], 'Trailing underscores are removed.');
+		assert.sameMembers(generateLocales('en-'), ['en'], 'Trailing hyphens are removed.');
+		assert.sameMembers(generateLocales('en-.UTF8'), ['en'], 'Trailing hyphens are removed.');
+		assert.sameMembers(generateLocales('en_'), ['en'], 'Trailing underscores are removed.');
+		assert.sameMembers(generateLocales('en_.UTF8'), ['en'], 'Trailing underscores are removed.');
 	},
 
 	normalizeLocale() {
 		assert.strictEqual(normalizeLocale('en'), 'en');
 		assert.strictEqual(normalizeLocale('en-US'), 'en-US');
 		assert.strictEqual(normalizeLocale('en-US-POSIX'), 'en-US-POSIX');
-		assert.strictEqual(normalizeLocale('en_US.UTF8'), 'en-US',
-			'Node-style locales are normalize.');
-		assert.strictEqual(normalizeLocale('en_US_POSIX.UTF8'), 'en-US-POSIX',
-			'Node-style locales are normalize.');
+		assert.strictEqual(normalizeLocale('en_US.UTF8'), 'en-US', 'Node-style locales are normalize.');
+		assert.strictEqual(normalizeLocale('en_US_POSIX.UTF8'), 'en-US-POSIX', 'Node-style locales are normalize.');
 
 		assert.strictEqual(normalizeLocale('en-'), 'en', 'Trailing hyphens are removed.');
 		assert.strictEqual(normalizeLocale('en-.UTF8'), 'en', 'Trailing hyphens are removed.');
 		assert.strictEqual(normalizeLocale('en_'), 'en', 'Trailing underscores are removed.');
 		assert.strictEqual(normalizeLocale('en_.UTF8'), 'en', 'Trailing underscores are removed.');
 
-		const validLocales = [ 'de', 'de-', 'deu', 'deu-', 'de-DE', 'de-DE-', 'deu-DE', 'deu-DE-', 'de-DE-bavarian',
-			'de-DE-bavarian-', 'deu-DE-bavarian', 'deu-DE-bavarian-', 'en-001', 'en-x-custom_value' ];
-		const invalidLocales = [ 'd', 'deut', 'de2', '@!4' ];
+		const validLocales = [
+			'de',
+			'de-',
+			'deu',
+			'deu-',
+			'de-DE',
+			'de-DE-',
+			'deu-DE',
+			'deu-DE-',
+			'de-DE-bavarian',
+			'de-DE-bavarian-',
+			'deu-DE-bavarian',
+			'deu-DE-bavarian-',
+			'en-001',
+			'en-x-custom_value'
+		];
+		const invalidLocales = ['d', 'deut', 'de2', '@!4'];
 
 		validLocales.forEach((locale: string) => {
 			assert.doesNotThrow(() => {
@@ -44,16 +57,28 @@ registerSuite('util/main', {
 			});
 		});
 		invalidLocales.forEach((locale: string) => {
-			assert.throws(() => {
-				normalizeLocale(locale);
-			}, Error, `${locale} is not a valid locale.`);
+			assert.throws(
+				() => {
+					normalizeLocale(locale);
+				},
+				Error,
+				`${locale} is not a valid locale.`
+			);
 		});
 	},
 
 	validateLocale() {
-		const validLocales = [ 'de', 'deu', 'de-DE', 'deu-DE', 'de-DE-bavarian', 'deu-DE-bavarian',
-			'en-001', 'en-x-custom_value' ];
-		const invalidLocales = [ 'd', 'deut', 'de2', '@!4' ];
+		const validLocales = [
+			'de',
+			'deu',
+			'de-DE',
+			'deu-DE',
+			'de-DE-bavarian',
+			'deu-DE-bavarian',
+			'en-001',
+			'en-x-custom_value'
+		];
+		const invalidLocales = ['d', 'deut', 'de2', '@!4'];
 
 		validLocales.forEach((locale: string) => {
 			assert.isTrue(validateLocale(locale));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"module": "umd",
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"noUnusedLocals": true,
 		"strictNullChecks": true,
 		"outDir": "_build/",
 		"removeComments": false,

--- a/tslint.json
+++ b/tslint.json
@@ -30,15 +30,12 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -58,8 +55,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206
