### PR TITLE
Import only root Globalize module

### DIFF
--- a/src/cldr/load.ts
+++ b/src/cldr/load.ts
@@ -1,6 +1,6 @@
 // required for Globalize/Cldr to properly resolve locales in the browser.
 import 'cldrjs/dist/cldr/unresolved';
-import * as Globalize from 'globalize';
+import * as Globalize from 'globalize/dist/globalize';
 import supportedLocales from './locales';
 import { generateLocales, validateLocale } from '../util/main';
 

--- a/src/util/globalize.ts
+++ b/src/util/globalize.ts
@@ -1,4 +1,4 @@
-import * as Globalize from 'globalize';
+import * as Globalize from 'globalize/dist/globalize';
 import i18n from '../i18n';
 
 /**


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

When referencing the Globalize constructor, import only the core module rather than the entire package.

Resolves #120 
